### PR TITLE
v2 Bugfix

### DIFF
--- a/core/component.go
+++ b/core/component.go
@@ -117,17 +117,18 @@ func (r *ComponentResource) Delete() error {
 
 	// TODO we should really be going through and deleting all instances... it would just be a lot of requests
 
-	current, err := r.CurrentRelease()
-	if current != nil {
-		// TODO should do something more formal here...
-		fmt.Println(err)
-		current.Delete()
-	}
 	target, err := r.TargetRelease()
 	if target != nil {
 		// TODO
 		fmt.Println(err)
 		target.Delete()
+	}
+
+	current, err := r.CurrentRelease()
+	if current != nil {
+		// TODO should do something more formal here...
+		fmt.Println(err)
+		current.Delete()
 	}
 	return r.collection.core.DB.Delete(r.collection, r.Name)
 }

--- a/core/resource.go
+++ b/core/resource.go
@@ -69,12 +69,10 @@ func getItemsPtrAndItemType(r interface{}) (reflect.Value, reflect.Type) {
 	// allows us to utilize the type with reflect.New().
 	itemType := itemsPtr.Type().Elem().Elem()
 
-	// fmt.Println(fmt.Sprintf("m: %#v", m))
-	// fmt.Println(fmt.Sprintf("interfaceValue: %#v", interfaceValue))
-	// fmt.Println(fmt.Sprintf("modelValue: %#v", modelValue))
-	// fmt.Println(fmt.Sprintf("itemsField: %#v", itemsField))
-	// fmt.Println(fmt.Sprintf("itemsPtr: %#v", itemsPtr))
-	// fmt.Println(fmt.Sprintf("itemType: %#v", itemType))
+	// This initializes the empty items slice, so that we don't return null in API
+	itemPtrType := reflect.PtrTo(itemType)
+	emptyItems := reflect.MakeSlice(reflect.SliceOf(itemPtrType), 0, 0)
+	itemsPtr.Set(emptyItems)
 
 	return itemsPtr, itemType
 }


### PR DESCRIPTION
- initialize empty items slice instead of returning null on Resource
  List objects
- rescue on missing Resource etcd root key
- delete target release first when deleting component, since it may have
  assumed control of volumes -- otherwise the volume cannot be deleted
  by the current release and times out