### PR TITLE
Resize EBS volumes on Instance Start

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -16,9 +16,11 @@
 
 ## v0.3.x
 
-* special release changes: service updates, load balancer port removal
+* ~~volume resizing~~
 
-* volume resizing
+* delete releases on component delete (bugfix)
+
+* special release changes: service updates, load balancer port removal
 
 * use AWS meta endpoint to get required info
 

--- a/client/client.go
+++ b/client/client.go
@@ -61,7 +61,7 @@ func (c *Client) request(method string, path string, in interface{}, out interfa
 		return false, err
 	}
 
-	fmt.Println(*req)
+	// fmt.Println(*req)
 
 	resp, err := c.http.Do(req)
 	if err != nil {

--- a/client/instance.go
+++ b/client/instance.go
@@ -103,8 +103,12 @@ func (r *InstanceResource) Stop() error {
 }
 
 func (r *InstanceResource) WaitForStarted() error {
+
+	// NOTE wait is set extremely high for instance start, since it can take a
+	// very long time for snapshots on large volumes (when resizing volumes).
+
 	desc := fmt.Sprintf("Instance start: %s", r.Name)
-	return waitFor(desc, 120*time.Second, 3*time.Second, func() (bool, error) {
+	return waitFor(desc, 4*time.Hour, 5*time.Second, func() (bool, error) {
 		if err := r.Reload(); err != nil {
 			return false, err
 		}
@@ -113,8 +117,12 @@ func (r *InstanceResource) WaitForStarted() error {
 }
 
 func (r *InstanceResource) WaitForStopped() error {
+
+	// TODO instead of an arbitrarily high timeout, this could maybe be adjusted
+	// dynamically based on the TerminationGracePeriod setting.
+
 	desc := fmt.Sprintf("Instance stop: %s", r.Name)
-	return waitFor(desc, 120*time.Second, 3*time.Second, func() (bool, error) {
+	return waitFor(desc, 10*time.Minute, 3*time.Second, func() (bool, error) {
 		if err := r.Reload(); err != nil {
 			return false, err
 		}

--- a/core/aws_volume.go
+++ b/core/aws_volume.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/supergiant/supergiant/types"
 
@@ -21,12 +22,12 @@ func (m *AwsVolume) name() string {
 	return fmt.Sprintf("%s-%s", m.Instance.BaseName, *m.Blueprint.Name)
 }
 
-func (m *AwsVolume) id() string {
+func (m *AwsVolume) id() *string {
 	vol := m.awsVolume()
 	if vol == nil {
 		panic(fmt.Errorf("Trying to access ID of nil volume %#v", m))
 	}
-	return *vol.VolumeId
+	return vol.VolumeId
 }
 
 // simple memoization of aws vol record
@@ -46,6 +47,16 @@ func (m *AwsVolume) loadAwsVolume() {
 					aws.String(m.name()),
 				},
 			},
+			// The following 3 state filters are used in order to not load volumes
+			// that are in a deleting state.
+			{
+				Name: aws.String("status"),
+				Values: []*string{
+					aws.String("creating"),
+					aws.String("available"),
+					aws.String("in-use"),
+				},
+			},
 		},
 	}
 	resp, err := m.core.EC2.DescribeVolumes(input)
@@ -59,11 +70,12 @@ func (m *AwsVolume) loadAwsVolume() {
 	// Volume does not exist otherwise and that's fine
 }
 
-func (m *AwsVolume) createAwsVolume() error {
+func (m *AwsVolume) createAwsVolume(snapshotID *string) error {
 	volInput := &ec2.CreateVolumeInput{
 		AvailabilityZone: aws.String(AwsAZ),
 		VolumeType:       aws.String(m.Blueprint.Type),
 		Size:             aws.Int64(int64(m.Blueprint.Size)),
+		SnapshotId:       snapshotID,
 	}
 
 	awsVol, err := m.core.EC2.CreateVolume(volInput)
@@ -88,9 +100,36 @@ func (m *AwsVolume) createAwsVolume() error {
 	return nil
 }
 
+func (m *AwsVolume) createSnapshot() (*ec2.Snapshot, error) {
+	input := &ec2.CreateSnapshotInput{
+		Description: aws.String(m.name() + "-" + *m.Instance.Release().Timestamp),
+		VolumeId:    m.id(),
+	}
+	snapshot, err := m.core.EC2.CreateSnapshot(input)
+	if err != nil {
+		return nil, err
+	}
+	waitInput := &ec2.DescribeSnapshotsInput{
+		SnapshotIds: []*string{snapshot.SnapshotId},
+	}
+	if err := m.core.EC2.WaitUntilSnapshotCompleted(waitInput); err != nil {
+		return snapshot, err // TODO
+	}
+	return snapshot, nil
+}
+
+func (m *AwsVolume) deleteSnapshot(snapshot *ec2.Snapshot) error {
+	input := &ec2.DeleteSnapshotInput{
+		SnapshotId: snapshot.SnapshotId,
+	}
+	_, err := m.core.EC2.DeleteSnapshot(input)
+	return err
+}
+
 func (m *AwsVolume) Provision() error {
 	if m.awsVolume() == nil {
-		return m.createAwsVolume()
+		log.Printf("Creating EBS volume %s", m.name())
+		return m.createAwsVolume(nil)
 	}
 	return nil
 }
@@ -101,25 +140,58 @@ func (m *AwsVolume) WaitForAvailable() error {
 			{
 				Name: aws.String("volume-id"),
 				Values: []*string{
-					aws.String(m.id()),
+					m.id(),
 				},
 			},
 		},
 	}
+	log.Printf("Waiting for EBS volume %s to be available", m.name())
 	return m.core.EC2.WaitUntilVolumeAvailable(input)
 }
 
 // Delete deletes the EBS volume on AWS.
 func (m *AwsVolume) Delete() error {
-	if m.awsVolume() == nil {
+	if m.awsVolume() == nil { // || *m.awsVolume().State == "deleting" {
 		return nil
 	}
 	if err := m.WaitForAvailable(); err != nil {
 		return err
 	}
 	input := &ec2.DeleteVolumeInput{
-		VolumeId: aws.String(m.id()),
+		VolumeId: m.id(),
 	}
-	_, err := m.core.EC2.DeleteVolume(input)
-	return err
+	log.Printf("Deleting EBS volume %s", m.name())
+	if _, err := m.core.EC2.DeleteVolume(input); err != nil {
+		return err
+	}
+	m.awsVol = nil
+	return nil
+}
+
+// NeedsResize returns true if the actual EBS size does not match the blueprint.
+func (m *AwsVolume) NeedsResize() bool {
+	if m.awsVolume() == nil {
+		return false
+	}
+	return int64(m.Blueprint.Size) != *m.awsVolume().Size
+}
+
+// Resize snapshots the volume, creates a new volume from the snapshot, deletes
+// the old volume, and renames the new volume to have the old name.
+func (m *AwsVolume) Resize() error {
+	log.Printf("Resizing EBS volume %s", m.name())
+	snapshot, err := m.createSnapshot()
+	if err != nil {
+		return err
+	}
+	if err := m.Delete(); err != nil {
+		return err
+	}
+	if err := m.createAwsVolume(snapshot.SnapshotId); err != nil {
+		return err
+	}
+	if err := m.deleteSnapshot(snapshot); err != nil {
+		log.Printf("Error deleting snapshot %s: %s", *snapshot.SnapshotId, err.Error())
+	}
+	return nil
 }

--- a/core/component.go
+++ b/core/component.go
@@ -1,7 +1,7 @@
 package core
 
 import (
-	"fmt"
+	"log"
 	"path"
 
 	"github.com/supergiant/supergiant/types"
@@ -119,15 +119,13 @@ func (r *ComponentResource) Delete() error {
 
 	target, err := r.TargetRelease()
 	if target != nil {
-		// TODO
-		fmt.Println(err)
+		log.Println(err)
 		target.Delete()
 	}
 
 	current, err := r.CurrentRelease()
 	if current != nil {
-		// TODO should do something more formal here...
-		fmt.Println(err)
+		log.Println(err)
 		current.Delete()
 	}
 	return r.collection.core.DB.Delete(r.collection, r.Name)

--- a/core/kube_helpers.go
+++ b/core/kube_helpers.go
@@ -54,6 +54,11 @@ func asKubeContainer(m *types.ContainerBlueprint, instance *InstanceResource) *g
 		},
 		VolumeMounts: kubeVolumeMounts(m),
 		Ports:        kubeContainerPorts(m),
+
+		// TODO this should be an option, enabled by default with volumes
+		SecurityContext: &guber.SecurityContext{
+			Privileged: true,
+		},
 	}
 }
 
@@ -79,7 +84,7 @@ func asKubeVolume(m *AwsVolume) *guber.Volume {
 	return &guber.Volume{
 		Name: *m.Blueprint.Name, // NOTE this is not the physical volume name
 		AwsElasticBlockStore: &guber.AwsElasticBlockStore{
-			VolumeID: m.id(),
+			VolumeID: *m.id(),
 			FSType:   "ext4",
 		},
 	}

--- a/core/release.go
+++ b/core/release.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"fmt"
+	"log"
 	"path"
 	"strconv"
 	"time"
@@ -229,6 +230,7 @@ func (r *ReleaseResource) provisionService(name string, svcType string, svcPorts
 			Ports: svcPorts,
 		},
 	}
+	log.Printf("Creating Service %s", name)
 	return r.collection.core.K8S.Services(*r.App().Name).Create(service)
 }
 
@@ -269,9 +271,11 @@ func (r *ReleaseResource) provisionInternalService() error {
 }
 
 func (r *ReleaseResource) deleteServices() (err error) {
+	log.Printf("Deleting Service %s", r.externalServiceName())
 	if _, err = r.collection.core.K8S.Services(*r.App().Name).Delete(r.externalServiceName()); err != nil {
 		return err
 	}
+	log.Printf("Deleting Service %s", r.internalServiceName())
 	if _, err = r.collection.core.K8S.Services(*r.App().Name).Delete(r.internalServiceName()); err != nil {
 		return err
 	}
@@ -390,23 +394,12 @@ func (r *ReleaseResource) Provision() error {
 			return err
 		}
 	}
-	for _, vol := range r.volumes() {
-		if err := vol.WaitForAvailable(); err != nil {
-			return err
-		}
-	}
-
-	// c := make(chan error)
-	// for _, instance := range r.Instances().List().Items {
-	// 	go func(instance *InstanceResource) { // NOTE we have to pass instance here, else every goroutine hits the same instance
-	// 		c <- instance.ProvisionVolumes()
-	// 	}(instance)
-	// }
-	// for i := 0; i < r.InstanceCount; i++ {
-	// 	if err := <-c; err != nil {
+	// for _, vol := range r.volumes() {
+	// 	if err := vol.WaitForAvailable(); err != nil {
 	// 		return err
 	// 	}
 	// }
+
 	return nil
 }
 

--- a/core/task.go
+++ b/core/task.go
@@ -2,8 +2,9 @@ package core
 
 import (
 	"encoding/json"
-	"fmt"
+	"log"
 	"path"
+	"strconv"
 
 	"github.com/supergiant/supergiant/types"
 )
@@ -147,7 +148,7 @@ func (r *TaskResource) Claim() error {
 }
 
 func (r *TaskResource) RecordError(err error) error {
-	fmt.Println("ERROR: ", err.Error()) // TODO
+	log.Println(err)
 
 	r.Error = err.Error()
 	if r.Attempts < r.MaxAttempts {
@@ -158,4 +159,21 @@ func (r *TaskResource) RecordError(err error) error {
 	r.Attempts++
 
 	return r.Save()
+}
+
+func (r *TaskResource) TypeName() string {
+	switch r.Type {
+	case types.TaskTypeDeleteApp:
+		return "DeleteApp"
+	case types.TaskTypeDeleteComponent:
+		return "DeleteComponent"
+	case types.TaskTypeDeployComponent:
+		return "DeployComponent"
+	case types.TaskTypeStartInstance:
+		return "StartInstance"
+	case types.TaskTypeStopInstance:
+		return "StopInstance"
+	default:
+		return strconv.Itoa(int(r.Type))
+	}
 }

--- a/main.go
+++ b/main.go
@@ -58,7 +58,7 @@ func main() {
 		router := api.NewRouter(core)
 
 		log.Println("INFO: Serving API on port :8080")
-		log.Fatal(http.ListenAndServe(":8080", router))
+		log.Println(http.ListenAndServe(":8080", router))
 	}
 
 	app.Flags = []cli.Flag{

--- a/types/resources.go
+++ b/types/resources.go
@@ -18,13 +18,12 @@ func NewMeta() *Meta {
 }
 
 type App struct {
-	*Meta
 	Name ID `json:"name"`
+	*Meta
 }
 
 // see note in core/resource.go about PersistableObject()
 type PersistableComponent struct {
-	*Meta
 	Name ID `json:"name"`
 	// TODO kinda weird,
 	// you choose a container that has the deploy file, and then reference it as a command
@@ -37,6 +36,8 @@ type PersistableComponent struct {
 	// We should just store the DeployTaskID but actually should render the task
 	// when showing it in HTTP.
 	DeployTaskID ID `json:"deploy_task_id"`
+
+	*Meta
 }
 
 type Component struct {
@@ -125,13 +126,14 @@ type ResourceAllocation struct {
 // NOTE the word Blueprint is used for Volumes and Containers, since they are
 // both "definitions" that create "instances" of the real thing
 type Release struct {
-	*Meta
 	// NOTE Timestamp here does not use the Timestamp type.
 	Timestamp              ID                    `json:"timestamp"`
 	InstanceCount          int                   `json:"instance_count"`
 	Volumes                []*VolumeBlueprint    `json:"volumes"`
 	Containers             []*ContainerBlueprint `json:"containers"`
 	TerminationGracePeriod int                   `json:"termination_grace_period"`
+
+	*Meta
 }
 
 // Instance
@@ -158,12 +160,13 @@ type Instance struct {
 // Entrypoint
 //==============================================================================
 type Entrypoint struct {
-	*Meta
 	Domain  ID     `json:"domain"`  // e.g. blog.qbox.io
 	Address string `json:"address"` // the ELB address
 
 	// NOTE we actually don't need this -- we can always attach the policy, and enable per port
 	// IPWhitelistEnabled bool   `json:"ip_whitelist_enabled"`
+
+	*Meta
 }
 
 // Task
@@ -180,19 +183,21 @@ const (
 )
 
 type Task struct {
-	*Meta
 	Type        TaskType `json:"type"`
 	Data        []byte   `json:"data"`
 	Status      string   `json:"status"`
 	Attempts    int      `json:"attempts"`
 	MaxAttempts int      `json:"max_attempts"` // this is static; config-level
 	Error       string   `json:"error"`
+
+	*Meta
 }
 
 // ImageRepo
 //==============================================================================
 type ImageRepo struct {
-	*Meta
 	Name ID     `json:"name"`
 	Key  string `json:"key"`
+
+	*Meta
 }


### PR DESCRIPTION
Additionally,
- add more formal logging around critical actions
- enable privileged security context on all containers (which needs
  revisiting for security reasons); allow user to use resize2fs to
  resize filesystems in container start
- fix some general issues with v0.2.x deploys