### PR TITLE
Enabled guber https aware mode in the API.

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -30,10 +30,10 @@ var (
 	AwsSubnetID string
 )
 
-func New() *Core {
+func New(httpsMode bool) *Core {
 	c := Core{}
 	c.DB = NewDB(EtcdEndpoints)
-	c.K8S = guber.NewClient(K8sHost, K8sUser, K8sPass)
+	c.K8S = guber.NewClient(K8sHost, K8sUser, K8sPass, httpsMode)
 	// NOTE / TODO AWS is configured through a file in ~
 	awsConf := &aws.Config{Region: aws.String(AwsRegion)}
 	c.EC2 = ec2.New(session.New(), awsConf)

--- a/main.go
+++ b/main.go
@@ -49,7 +49,7 @@ func main() {
 		log.Println("INFO: ETCD hosts,", c.StringSlice("etcd-host"))
 		log.Println("INFO: Kubernetes Host,", core.K8sHost)
 
-		core := core.New()
+		core := core.New(c.Bool("https-mode"))
 
 		// TODO should probably be able to say api.New(), because we shouldn't have to import task here
 		// NOTE using pool size of 4
@@ -115,6 +115,11 @@ func main() {
 			Usage:       "AWS Subnet ID in which your kubernetes cluster resides.",
 			EnvVar:      "AWS_SUBNET_ID",
 			Destination: &core.AwsSubnetID,
+		},
+		cli.BoolFlag{
+			Name:   "https-mode",
+			Usage:  "Enable https mode for guber client when running outside a kube.",
+			EnvVar: "HTTPS_MODE",
 		},
 	}
 


### PR DESCRIPTION
The option can be turned on and off using a flag.

		cli.BoolFlag{
			Name:   "https-mode",
			Usage:  "Enable https mode for guber client when running outside a kube.",
			EnvVar: "HTTPS_MODE",
		},