### PR TITLE
Don't return error when image repo in Release does not exist

### DIFF
--- a/core/release.go
+++ b/core/release.go
@@ -558,6 +558,15 @@ func (r *ReleaseResource) getImageRepos() (repos []*ImageRepoResource, err error
 	for _, repoName := range r.imageRepoNames() {
 		repo, err := r.collection.core.ImageRepos().Get(&repoName)
 		if err != nil {
+
+			// TODO this method is ambiguously named
+			if isNotFoundError(err) {
+				// if there is no repo, we can assume this is a public repo (though it
+				// may not be) -- this represents a TODO on how to report errors from
+				// Kubernetes
+				continue
+			}
+
 			return nil, err
 		}
 		repos = append(repos, repo)


### PR DESCRIPTION
This allows for using public Docker repos.