### PR TITLE
Don't create Kube services when there's no ports

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -32,6 +32,8 @@
 
 * show instance metrics
 
+* internal ELBs
+
 ## v0.6.x
 
 *will probably use this release to organize some docs / tests*

--- a/core/release.go
+++ b/core/release.go
@@ -232,6 +232,11 @@ func (r *ReleaseResource) getService(name string) (*guber.Service, error) {
 }
 
 func (r *ReleaseResource) provisionService(name string, svcType string, svcPorts []*guber.ServicePort) (*guber.Service, error) {
+	// doing this here so I don't have to repeat in both external and internal provision methods
+	if len(svcPorts) == 0 {
+		return nil, nil
+	}
+
 	if service, _ := r.getService(name); service != nil {
 		return service, nil // already created
 	}


### PR DESCRIPTION
This was causing a failure when creating Components with no ports.