### PR TITLE
Render errors as JSON in the API

### DIFF
--- a/api/app_controller.go
+++ b/api/app_controller.go
@@ -21,7 +21,7 @@ func (c *AppController) Create(w http.ResponseWriter, r *http.Request) {
 
 	app, err := c.core.Apps().Create(app)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		renderError(w, err, http.StatusInternalServerError)
 		return
 	}
 
@@ -35,7 +35,7 @@ func (c *AppController) Create(w http.ResponseWriter, r *http.Request) {
 func (c *AppController) Index(w http.ResponseWriter, r *http.Request) {
 	apps, err := c.core.Apps().List()
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		renderError(w, err, http.StatusInternalServerError)
 		return
 	}
 
@@ -68,7 +68,7 @@ func (c *AppController) Delete(w http.ResponseWriter, r *http.Request) {
 	msg := &task.DeleteAppMessage{AppName: app.Name}
 	_, err = c.core.Tasks().Start(types.TaskTypeDeleteApp, msg)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		renderError(w, err, http.StatusInternalServerError)
 		return
 	}
 

--- a/api/component_controller.go
+++ b/api/component_controller.go
@@ -25,7 +25,7 @@ func (c *ComponentController) Create(w http.ResponseWriter, r *http.Request) {
 
 	component, err = app.Components().Create(component)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		renderError(w, err, http.StatusInternalServerError)
 		return
 	}
 
@@ -44,7 +44,7 @@ func (c *ComponentController) Index(w http.ResponseWriter, r *http.Request) {
 
 	components, err := app.Components().List()
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		renderError(w, err, http.StatusInternalServerError)
 		return
 	}
 
@@ -80,7 +80,7 @@ func (c *ComponentController) Delete(w http.ResponseWriter, r *http.Request) {
 	}
 	_, err = c.core.Tasks().Start(types.TaskTypeDeleteComponent, msg)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		renderError(w, err, http.StatusInternalServerError)
 		return
 	}
 

--- a/api/entrypoint_controller.go
+++ b/api/entrypoint_controller.go
@@ -19,7 +19,7 @@ func (c *EntrypointController) Create(w http.ResponseWriter, r *http.Request) {
 
 	entrypoint, err := c.core.Entrypoints().Create(entrypoint)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		renderError(w, err, http.StatusInternalServerError)
 		return
 	}
 
@@ -33,7 +33,7 @@ func (c *EntrypointController) Create(w http.ResponseWriter, r *http.Request) {
 func (c *EntrypointController) Index(w http.ResponseWriter, r *http.Request) {
 	entrypoints, err := c.core.Entrypoints().List()
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		renderError(w, err, http.StatusInternalServerError)
 		return
 	}
 
@@ -63,7 +63,7 @@ func (c *EntrypointController) Delete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err = entrypoint.Delete(); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		renderError(w, err, http.StatusInternalServerError)
 		return
 	}
 

--- a/api/image_repo_controller.go
+++ b/api/image_repo_controller.go
@@ -19,7 +19,7 @@ func (c *ImageRepoController) Create(w http.ResponseWriter, r *http.Request) {
 
 	repo, err := c.core.ImageRepos().Create(repo)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		renderError(w, err, http.StatusInternalServerError)
 		return
 	}
 
@@ -36,7 +36,7 @@ func (c *ImageRepoController) Delete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err = repo.Delete(); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		renderError(w, err, http.StatusInternalServerError)
 		return
 	}
 

--- a/api/instance_controller.go
+++ b/api/instance_controller.go
@@ -54,7 +54,7 @@ func (c *InstanceController) Start(w http.ResponseWriter, r *http.Request) {
 	}
 	_, err = c.core.Tasks().Start(types.TaskTypeStartInstance, msg)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		renderError(w, err, http.StatusInternalServerError)
 		return
 	}
 
@@ -79,7 +79,7 @@ func (c *InstanceController) Stop(w http.ResponseWriter, r *http.Request) {
 	}
 	_, err = c.core.Tasks().Start(types.TaskTypeStopInstance, msg)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		renderError(w, err, http.StatusInternalServerError)
 		return
 	}
 

--- a/api/release_controller.go
+++ b/api/release_controller.go
@@ -25,7 +25,7 @@ func (c *ReleaseController) Create(w http.ResponseWriter, r *http.Request) {
 
 	release, err = component.Releases().Create(release)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		renderError(w, err, http.StatusInternalServerError)
 		return
 	}
 
@@ -35,7 +35,7 @@ func (c *ReleaseController) Create(w http.ResponseWriter, r *http.Request) {
 	}
 	task, err := c.core.Tasks().Start(types.TaskTypeDeployComponent, msg)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		renderError(w, err, http.StatusInternalServerError)
 		return
 	}
 
@@ -44,7 +44,7 @@ func (c *ReleaseController) Create(w http.ResponseWriter, r *http.Request) {
 	// Set the task ID of the deploy on Component
 	component.DeployTaskID = task.ID
 	if err := component.Save(); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		renderError(w, err, http.StatusInternalServerError)
 		return
 	}
 
@@ -63,7 +63,7 @@ func (c *ReleaseController) Index(w http.ResponseWriter, r *http.Request) {
 
 	releases, err := component.Releases().List()
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		renderError(w, err, http.StatusInternalServerError)
 		return
 	}
 

--- a/api/task_controller.go
+++ b/api/task_controller.go
@@ -13,7 +13,7 @@ type TaskController struct {
 func (c *TaskController) Index(w http.ResponseWriter, r *http.Request) {
 	tasks, err := c.core.Tasks().List()
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		renderError(w, err, http.StatusInternalServerError)
 		return
 	}
 


### PR DESCRIPTION
A side note: I would like to eventually implement DRYer error handling
as shown in this article: http://blog.golang.org/error-handling-and-go.

Unfortunately, I'm not sure that strategy will work with mux, the HTTP
router we are using. I think the answer is Middleware, but whatever the
case, we need to be able to define our CRUD actions as funcs that return
an error. Then, in only one spot, we will control the formatting and
rendering of the error.