### PR TITLE
Allow partial/empty Release

### DIFF
--- a/api/image_repo_controller.go
+++ b/api/image_repo_controller.go
@@ -30,6 +30,43 @@ func (c *ImageRepoController) Create(w http.ResponseWriter, r *http.Request) {
 	renderWithStatusCreated(w, body)
 }
 
+func (c *ImageRepoController) Index(w http.ResponseWriter, r *http.Request) {
+	repos, err := c.core.ImageRepos().List()
+	if err != nil {
+		renderError(w, err, http.StatusInternalServerError)
+		return
+	}
+
+	// TODO we need a consistent way of stripping sensitive fields from API responses.
+	// And we also need a validation that key is not saved empty -- because this could cause that if someone updates tags or something.
+	for _, repo := range repos.Items {
+		repo.Key = ""
+	}
+
+	body, err := marshalBody(w, repos)
+	if err != nil {
+		return
+	}
+	renderWithStatusOK(w, body)
+}
+
+func (c *ImageRepoController) Show(w http.ResponseWriter, r *http.Request) {
+	repo, err := loadImageRepo(c.core, w, r)
+	if err != nil {
+		return
+	}
+
+	// TODO we need a consistent way of stripping sensitive fields from API responses.
+	// And we also need a validation that key is not saved empty -- because this could cause that if someone updates tags or something.
+	repo.Key = ""
+
+	body, err := marshalBody(w, repo)
+	if err != nil {
+		return
+	}
+	renderWithStatusOK(w, body)
+}
+
 func (c *ImageRepoController) Delete(w http.ResponseWriter, r *http.Request) {
 	repo, err := loadImageRepo(c.core, w, r)
 	if err != nil {
@@ -39,12 +76,4 @@ func (c *ImageRepoController) Delete(w http.ResponseWriter, r *http.Request) {
 		renderError(w, err, http.StatusInternalServerError)
 		return
 	}
-
-	// TODO what do we return on immediate deletes like this? generic OK message?
-
-	// body, err := marshalBody(w, app)
-	// if err != nil {
-	// 	return
-	// }
-	// renderWithStatusAccepted(w, body)
 }

--- a/api/router.go
+++ b/api/router.go
@@ -23,6 +23,8 @@ func NewRouter(core *core.Core) *mux.Router {
 	tasks := &TaskController{core}
 
 	s.HandleFunc("/registries/dockerhub/repos", imageRepos.Create).Methods("POST")
+	s.HandleFunc("/registries/dockerhub/repos", imageRepos.Index).Methods("GET")
+	s.HandleFunc("/registries/dockerhub/repos/{name}", imageRepos.Show).Methods("GET")
 	s.HandleFunc("/registries/dockerhub/repos/{name}", imageRepos.Delete).Methods("DELETE")
 
 	s.HandleFunc("/entrypoints", entrypoints.Create).Methods("POST")
@@ -43,9 +45,11 @@ func NewRouter(core *core.Core) *mux.Router {
 	s.HandleFunc("/apps/{app_name}/components/{comp_name}", components.Delete).Methods("DELETE")
 
 	s.HandleFunc("/apps/{app_name}/components/{comp_name}/releases", releases.Create).Methods("POST")
+	s.HandleFunc("/apps/{app_name}/components/{comp_name}/releases", releases.MergeCreate).Methods("PATCH")
 	s.HandleFunc("/apps/{app_name}/components/{comp_name}/releases", releases.Index).Methods("GET")
 	s.HandleFunc("/apps/{app_name}/components/{comp_name}/releases/{release_timestamp}", releases.Show).Methods("GET")
 	s.HandleFunc("/apps/{app_name}/components/{comp_name}/releases/{release_timestamp}", releases.Update).Methods("PUT")
+	s.HandleFunc("/apps/{app_name}/components/{comp_name}/releases/{release_timestamp}", releases.Delete).Methods("DELETE")
 
 	s.HandleFunc("/apps/{app_name}/components/{comp_name}/deploy", components.Deploy).Methods("POST")
 

--- a/api/task/deploy_component.go
+++ b/api/task/deploy_component.go
@@ -70,7 +70,7 @@ func (j DeployComponent) Perform(data []byte) error {
 	// Make sure old release (current) has been fully stopped, and the new release
 	// (target) has been fully started.
 	// It doesn't matter on the first deploy, though.
-	if currentRelease != nil {
+	if currentRelease != nil && *currentRelease.InstanceGroup != *targetRelease.InstanceGroup {
 		if !currentRelease.IsStopped() {
 			return fmt.Errorf("Current Release for Component %s:%s is not completely stopped.", common.StringID(app.Name), common.StringID(component.Name))
 		}

--- a/client/client.go
+++ b/client/client.go
@@ -133,6 +133,10 @@ func (c *Client) Post(path string, in interface{}, out interface{}) error {
 	return c.request("POST", path, in, out)
 }
 
+func (c *Client) Patch(path string, in interface{}, out interface{}) error {
+	return c.request("PATCH", path, in, out)
+}
+
 func (c *Client) Put(path string, in interface{}, out interface{}) error {
 	return c.request("PUT", path, in, out)
 }

--- a/client/release.go
+++ b/client/release.go
@@ -58,6 +58,14 @@ func (c *ReleaseCollection) Create(m *Release) (*ReleaseResource, error) {
 	return r, nil
 }
 
+func (c *ReleaseCollection) MergeCreate(m *Release) (*ReleaseResource, error) {
+	r := c.New(m)
+	if err := c.client.Patch(c.path(), m, r.Release); err != nil {
+		return nil, err
+	}
+	return r, nil
+}
+
 func (c *ReleaseCollection) Get(timestamp common.ID) (*ReleaseResource, error) {
 	m := &Release{
 		Timestamp: timestamp,

--- a/common/types.go
+++ b/common/types.go
@@ -124,6 +124,12 @@ type Release struct {
 	// NOTE Timestamp here does not use the Timestamp type.
 	Timestamp ID `json:"timestamp"`
 
+	// InstanceGroup is used as a labeling mechanism for instances. If nil,
+	// InstanceGroup is set equal to the release's Timestamp. If a value is
+	// supplied by the user, it MUST be the current (previous) Release's
+	// Timestamp.
+	InstanceGroup ID `json:"instance_group"`
+
 	InstanceCount int `json:"instance_count"`
 
 	// These attributes, when changed from last Release, indicate a restart is
@@ -205,7 +211,7 @@ type Task struct {
 //==============================================================================
 type ImageRepo struct {
 	Name ID     `json:"name"`
-	Key  string `json:"key"`
+	Key  string `json:"key,omitempty"`
 
 	*Meta
 }

--- a/core/instance.go
+++ b/core/instance.go
@@ -52,7 +52,7 @@ func (c *InstanceCollection) New(id common.ID) *InstanceResource {
 	}
 	// TODO not consistent with the setter approach
 	r.BaseName = common.StringID(r.Component().Name) + "-" + common.StringID(r.ID)
-	r.Name = r.BaseName + common.StringID(r.Release().Timestamp)
+	r.Name = r.BaseName + common.StringID(r.Release().InstanceGroup)
 	r.setStatus()
 	return r
 }

--- a/core/resource.go
+++ b/core/resource.go
@@ -20,6 +20,9 @@ type Collection interface {
 // Resource is an interface used mainly for generalized marshalling purposes for
 // resource common.
 type Resource interface {
+	// // ToApiObj allows for each resource to return a stripped or embellished
+	// // version of itself for rendering in API responses.
+	// ToApiObj() Resource
 }
 
 // OrderedResource is similar to Resource, but provides a SetID() method to
@@ -59,7 +62,7 @@ func getItemsPtrAndItemType(r interface{}) (reflect.Value, reflect.Type) {
 
 	// Must first get the pointer of the slice with Addr(), so we can then call
 	// Elem() to make it settable.
-	itemsPtr := itemsField //.Addr() //.Interface()
+	itemsPtr := itemsField
 	// Type() returns the underlying element type of the slice, and Elem()
 	// allows us to utilize the type with reflect.New().
 	itemType := itemsPtr.Type().Elem().Elem()
@@ -72,14 +75,6 @@ func getItemsPtrAndItemType(r interface{}) (reflect.Value, reflect.Type) {
 	return itemsPtr, itemType
 }
 
-// TODO all the following stuff should be better documented.
-
-// // used to initialize Meta object primarily
-// func initResource(r Resource) {
-// 	meta := reflect.ValueOf(common.NewMeta()).Elem()
-// 	getFieldValue(r.PersistableObject(), "Meta").Set(meta)
-// }
-
 func getFieldValue(r Resource, f string) reflect.Value {
 	field := reflect.ValueOf(r).Elem().FieldByName(f)
 	if !field.IsValid() {
@@ -89,7 +84,7 @@ func getFieldValue(r Resource, f string) reflect.Value {
 }
 
 func newTimestampValue() reflect.Value {
-	return reflect.ValueOf(common.NewTimestamp()) //.Elem()
+	return reflect.ValueOf(common.NewTimestamp())
 }
 
 func setCreatedTimestamp(r Resource) {

--- a/deploy/deploy.go
+++ b/deploy/deploy.go
@@ -83,6 +83,10 @@ func Deploy(appName *string, componentName *string) error {
 
 	// update instances
 
+	if currentRelease.InstanceGroup == targetRelease.InstanceGroup {
+		return nil // no need to update restart instances
+	}
+
 	// NOTE we only want to update the minimum of (target, current) instance
 	// counts. When adding instances, we wouldn't want to use target instance
 	// count because we would restart new instances. When removing instances, we

--- a/example.sh
+++ b/example.sh
@@ -16,7 +16,7 @@ curl -XPOST localhost:8080/v0/apps/test/components -d '{
 }'
 
 curl -XPOST localhost:8080/v0/apps/test/components/elasticsearch/releases -d '{
-  "instance_count": 3,
+  "instance_count": 1,
   "termination_grace_period": 10,
   "volumes": [
     {
@@ -78,7 +78,7 @@ curl -XPOST localhost:8080/v0/apps/test/components/elasticsearch/releases -d '{
         },
         {
           "name": "MIN_MASTER_NODES",
-          "value": "2"
+          "value": "1"
         },
         {
           "name": "CORES",


### PR DESCRIPTION
- add PATCH route for Release creation that utilizes MergeCreate to
  allow for submitting partial Release updates to be merged with the
  current Release
- tie Instances to Release InstanceGroup instead of Timestamp, to allow
  instances to be "handed off" between Releases without requiring
  restart

Additionally,
- add index/show routes for ImageRepos