### PR TITLE
Change bytes/cores value unmarshalling to match K8S

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -66,14 +66,14 @@ type VolumeBlueprint struct {
 // Container
 //==============================================================================
 type ContainerBlueprint struct {
-	Image   string              `json:"image"`
-	Name    string              `json:"name,omitempty"`
-	Command []string            `json:"command,omitempty"`
-	Ports   []*Port             `json:"ports"`
-	Env     []*EnvVar           `json:"env"`
-	CPU     *ResourceAllocation `json:"cpu"`
-	RAM     *ResourceAllocation `json:"ram"`
-	Mounts  []*Mount            `json:"mounts,omitempty"`
+	Image   string         `json:"image"`
+	Name    string         `json:"name,omitempty"`
+	Command []string       `json:"command,omitempty"`
+	Ports   []*Port        `json:"ports"`
+	Env     []*EnvVar      `json:"env"`
+	CPU     *CpuAllocation `json:"cpu"`
+	RAM     *RamAllocation `json:"ram"`
+	Mounts  []*Mount       `json:"mounts,omitempty"`
 }
 
 // EnvVar
@@ -107,11 +107,14 @@ type Port struct {
 	ExternalNumber int `json:"external_number"`
 }
 
-// ResourceAllocation
-//==============================================================================
-type ResourceAllocation struct {
-	Min uint `json:"min"`
-	Max uint `json:"max"`
+type CpuAllocation struct {
+	Min *CoresValue `json:"min"`
+	Max *CoresValue `json:"max"`
+}
+
+type RamAllocation struct {
+	Min *BytesValue `json:"min"`
+	Max *BytesValue `json:"max"`
 }
 
 // Release

--- a/core/core.go
+++ b/core/core.go
@@ -46,6 +46,8 @@ func SetLogLevel(level string) {
 		panic(err)
 	}
 	Log.Level = levelInt
+
+	// guber.Log.SetLevel(level)
 }
 
 // NOTE this used to be core.New(), but due to how we load in values from the

--- a/core/db.go
+++ b/core/db.go
@@ -145,7 +145,7 @@ func (db *database) compareAndSwap(r Collection, id common.ID, old Resource, new
 func stripNonDbFields(m Resource) interface{} { // we return a copy here so we don't strip fields on the actual object
 	rv := reflect.ValueOf(m).Elem()
 
-	rxp, _ := regexp.Compile("(.+)Resource")
+	rxp := regexp.MustCompile("(.+)Resource")
 	typeName := rxp.FindStringSubmatch(rv.Type().Name())[1]
 
 	oldT := rv.FieldByName(typeName).Elem()

--- a/core/kube_helpers.go
+++ b/core/kube_helpers.go
@@ -50,22 +50,26 @@ func asKubeContainer(m *common.ContainerBlueprint, instance *InstanceResource) *
 		Limits:   new(guber.ResourceValues),
 	}
 	if m.RAM != nil {
-		resources.Requests.Memory = common.BytesFromMiB(m.RAM.Min).ToKubeMebibytes()
-		if m.RAM.Max != 0 {
-			resources.Limits.Memory = common.BytesFromMiB(m.RAM.Max).ToKubeMebibytes()
+		if m.RAM.Min != nil {
+			resources.Requests.Memory = m.RAM.Min.ToKubeMebibytes()
+		}
+		if m.RAM.Max != nil {
+			resources.Limits.Memory = m.RAM.Max.ToKubeMebibytes()
 		}
 	}
 	if m.CPU != nil {
-		resources.Requests.CPU = common.CoresFromMillicores(m.CPU.Min).ToKubeMillicores()
-		if m.CPU.Max != 0 {
-			resources.Limits.CPU = common.CoresFromMillicores(m.CPU.Max).ToKubeMillicores()
+		if m.CPU.Min != nil {
+			resources.Requests.CPU = m.CPU.Min.ToKubeMillicores()
+		}
+		if m.CPU.Max != nil {
+			resources.Limits.CPU = m.CPU.Max.ToKubeMillicores()
 		}
 	}
 
 	// TODO
 	containerName := m.Name
 	if m.Name == "" {
-		rxp, _ := regexp.Compile("[^A-Za-z0-9]")
+		rxp := regexp.MustCompile("[^A-Za-z0-9]")
 		containerName = rxp.ReplaceAllString(m.Image, "-")
 	}
 

--- a/example.sh
+++ b/example.sh
@@ -34,12 +34,12 @@ curl -XPOST localhost:8080/v0/apps/test/components/elasticsearch/releases -d '{
     {
       "image": "qbox/qbox-docker:2.1.1",
       "cpu": {
-        "min": 0,
-        "max": 500
+        "min": 0.25,
+        "max": "500m"
       },
       "ram": {
-        "min": 2048,
-        "max": 2048
+        "min": "1.5Gi",
+        "max": "2048Mi"
       },
       "mounts": [
         {
@@ -55,7 +55,7 @@ curl -XPOST localhost:8080/v0/apps/test/components/elasticsearch/releases -d '{
         {
           "protocol": "HTTP",
           "number": 9200,
-          "external_number": 9200,
+          "external_number": 33666,
           "public": true,
           "entrypoint_domain": "example.com"
         },


### PR DESCRIPTION
When creating Releases, the API will now accept the following:

CPU:
  1 (int, cores)
  1.0 (float, cores)
  "1" (string, cores)
  "1.0" (string, cores)
  "1000m" (string, millicores)

  _which equals 1 core and will be displayed as **"1000m"** (in
  millicore notation)_

RAM:
  1073741824 (int, bytes)
  "1024Mi" (string, mebibytes)
  "1Gi" (string, gibibytes)
  "1.0Gi" (string, gibibytes)

  _which equals 1 gibibyte and will be displayed as **1024Mi** (in
  mebibyte notation_