### PR TITLE
Expose cpu/ram keys on Instance for Heapster stats

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -168,6 +168,9 @@ type Instance struct {
 	Name     string `json:"name"`
 
 	Status InstanceStatus `json:"status"`
+
+	CPU *ResourceMetrics `json:"cpu"`
+	RAM *ResourceMetrics `json:"ram"`
 }
 
 // Entrypoint


### PR DESCRIPTION
**how an Instance looks now**
```json
{
  "id": "0",
  "base_name": "elasticsearch-0",
  "name": "elasticsearch-020160422134458",
  "status": "STARTED"
}
```

**how an Instance will look**
```json
{
  "id": "0",
  "base_name": "elasticsearch-0",
  "name": "elasticsearch-020160422134458",
  "status": "STARTED",
  "cpu": {
    "usage": 2,
    "limit": 250
  },
  "ram": {
    "usage": 1279303680,
    "limit": 2147483648
  }
}
```