### PR TITLE
Add CoresValue and BytesValue init from string methods

### DIFF
--- a/common/values.go
+++ b/common/values.go
@@ -49,13 +49,13 @@ const (
 	gibibytes       = mebibytes * kibibytes
 )
 
-func (b *BytesValue) MarshalJSON() ([]byte, error) {
-	return []byte(`"` + b.ToKubeMebibytes() + `"`), nil
+func BytesFromString(str string) *BytesValue {
+	b := new(BytesValue)
+	b.fromString(str)
+	return b
 }
 
-func (b *BytesValue) UnmarshalJSON(raw []byte) error {
-	str := string(raw)
-
+func (b *BytesValue) fromString(str string) error {
 	rxp := regexp.MustCompile(`^"?([0-9]+(?:\.[0-9]+)?)([KMG]i)?"?$`)
 
 	if !rxp.MatchString(str) {
@@ -83,6 +83,14 @@ func (b *BytesValue) UnmarshalJSON(raw []byte) error {
 	return nil
 }
 
+func (b *BytesValue) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + b.ToKubeMebibytes() + `"`), nil
+}
+
+func (b *BytesValue) UnmarshalJSON(raw []byte) error {
+	return b.fromString(string(raw))
+}
+
 func (v *BytesValue) Mebibytes() float64 {
 	return float64(v.Bytes) / float64(mebibytes)
 }
@@ -101,13 +109,13 @@ type CoresValue struct {
 
 const millicores = 1000
 
-func (c *CoresValue) MarshalJSON() ([]byte, error) {
-	return []byte(`"` + c.ToKubeMillicores() + `"`), nil
+func CoresFromString(str string) *CoresValue {
+	c := new(CoresValue)
+	c.fromString(str)
+	return c
 }
 
-func (c *CoresValue) UnmarshalJSON(raw []byte) error {
-	str := string(raw)
-
+func (c *CoresValue) fromString(str string) error {
 	rxpMillicores := regexp.MustCompile(`^"([0-9]+)m"$`)        // 1000m
 	rxpCores := regexp.MustCompile(`^"?([0-9]+(\.[0-9]+)?)"?$`) // 1 (can have quotes)
 
@@ -140,9 +148,13 @@ func (c *CoresValue) UnmarshalJSON(raw []byte) error {
 	return nil
 }
 
-// func (v *CoresValue) cores() float64 {
-// 	return float64(v.millicores) / float64(millicores)
-// }
+func (c *CoresValue) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + c.ToKubeMillicores() + `"`), nil
+}
+
+func (c *CoresValue) UnmarshalJSON(raw []byte) error {
+	return c.fromString(string(raw))
+}
 
 func (v *CoresValue) ToKubeMillicores() string {
 	return fmt.Sprintf("%dm", v.Millicores)

--- a/core/capacity_service.go
+++ b/core/capacity_service.go
@@ -228,6 +228,9 @@ func (s *capacityService) incomingPods() (incomingPods []*guber.Pod, err error) 
 		incomingCount := len(incomingPods)
 
 		if incomingCount > 0 && elapsed < waitBeforeScale {
+
+			Log.Debugf("Waiting to add nodes for %d pods", incomingCount)
+
 			time.Sleep(2 * time.Second)
 		} else {
 			break

--- a/example.sh
+++ b/example.sh
@@ -34,12 +34,12 @@ curl -XPOST localhost:8080/v0/apps/test/components/elasticsearch/releases -d '{
     {
       "image": "qbox/qbox-docker:2.1.1",
       "cpu": {
-        "min": 2,
-        "max": 4
+        "min": 0,
+        "max": 0.5
       },
       "ram": {
-        "min": "12Gi",
-        "max": "16Gi"
+        "min": "1.5Gi",
+        "max": "2Gi"
       },
       "mounts": [
         {


### PR DESCRIPTION
@gopherstein to adjust your old 0.5.0 code, change:

```go
&ResourceAllocation{
  Min: minStr,
  Max: maxStr,
}
```

to

```go
&CpuAllocation{
  Min: common.CoresFromString(cpuMinStr),
  Max: common.CoresFromString(cpuMaxStr),
}
&RamAllocation{
  Min: common.BytesFromString(ramMinStr),
  Max: common.BytesFromString(ramMaxStr),
}
```