### PR TITLE
Null target_release_timestamp on successful deploy (fix)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 supergiant-api
 /tmp
+default.etcd

--- a/core/capacity_service.go
+++ b/core/capacity_service.go
@@ -248,6 +248,7 @@ func (s *capacityService) Run() {
 		incomingPods, err := s.incomingPods()
 		if err != nil {
 			Log.Errorf("Capacity service error when fetching incoming pods: %s", err)
+			continue
 		}
 
 		var projectedNodes []*projectedNode
@@ -307,7 +308,7 @@ func (s *capacityService) Run() {
 			}
 
 			//==========================================================================
-			// merge if found, OR scall down to the smallest instance size it can use and commit it
+			// merge if found, OR scale down to the smallest instance size it can use and commit it
 			//==========================================================================
 
 			if pnode2 != nil {

--- a/core/component.go
+++ b/core/component.go
@@ -192,7 +192,7 @@ func (c *ComponentCollection) Deploy(ri Resource) (err error) {
 	// If we're all good, we set target to current, and remove target.
 	r.CurrentReleaseTimestamp = r.TargetReleaseTimestamp
 	r.TargetReleaseTimestamp = nil
-	return r.Update()
+	return c.core.db.update(c, r.Name, r)
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
There was a regression with the validations branch that was merged
recently -- target_release_timestamp would retain its value after
successful deploy, causing subsequent release creation to return an
error.