### PR TITLE
Fix instance stats limit value

### DIFF
--- a/common/values.go
+++ b/common/values.go
@@ -112,7 +112,7 @@ func CoresFromString(str string) *CoresValue {
 }
 
 func (c *CoresValue) fromString(str string) error {
-	rxpMillicores := regexp.MustCompile(`^"([0-9]+)m"$`)        // 1000m
+	rxpMillicores := regexp.MustCompile(`^"?([0-9]+)m"?$`)      // 1000m
 	rxpCores := regexp.MustCompile(`^"?([0-9]+(\.[0-9]+)?)"?$`) // 1 (can have quotes)
 
 	getNumMatch := func(rxp *regexp.Regexp) (float64, error) {

--- a/core/instance.go
+++ b/core/instance.go
@@ -202,14 +202,21 @@ func (r *InstanceResource) decorate() error {
 		cpuUsage := stats.Stats["cpu-usage"]
 		memUsage := stats.Stats["memory-usage"]
 
+		// NOTE we took out the limit displayed by Heapster, and replaced it with
+		// the actual limit value assigned to the pod. Heapster was returning limit
+		// values less than the usage, which was causing errors when calculating
+		// percentages.
+
 		if cpuUsage != nil && memUsage != nil {
 			r.CPU = &common.ResourceMetrics{
 				Usage: cpuUsage.Minute.Average,
-				Limit: stats.Stats["cpu-limit"].Minute.Average,
+				Limit: totalCpuLimit(pod).Millicores,
+				// Limit: stats.Stats["cpu-limit"].Minute.Average,
 			}
 			r.RAM = &common.ResourceMetrics{
 				Usage: memUsage.Minute.Average,
-				Limit: stats.Stats["memory-limit"].Minute.Average,
+				Limit: int(totalRamLimit(pod).Bytes),
+				// Limit: stats.Stats["memory-limit"].Minute.Average,
 			}
 		}
 	}

--- a/core/kube_helpers.go
+++ b/core/kube_helpers.go
@@ -178,3 +178,20 @@ func asKubeSecret(m *ImageRepoResource) *guber.Secret {
 		},
 	}
 }
+
+// Misc
+func totalCpuLimit(pod *guber.Pod) *common.CoresValue {
+	cores := new(common.CoresValue)
+	for _, container := range pod.Spec.Containers {
+		cores.Millicores += common.CoresFromString(container.Resources.Limits.CPU).Millicores
+	}
+	return cores
+}
+
+func totalRamLimit(pod *guber.Pod) *common.BytesValue {
+	bytes := new(common.BytesValue)
+	for _, container := range pod.Spec.Containers {
+		bytes.Bytes += common.BytesFromString(container.Resources.Limits.Memory).Bytes
+	}
+	return bytes
+}


### PR DESCRIPTION
Swap Heapster-returned cpu-limit and memory-limit values with the sum of
limits listed on the actual pod resource. (Not sure if Heapster
reporting is messed up, or if we're misunderstanding something)