### PR TITLE
Recover from panic in Supervisor

### DIFF
--- a/core/supervisor.go
+++ b/core/supervisor.go
@@ -58,12 +58,12 @@ func (s *Supervisor) Run() {
 
 func (s *Supervisor) startWorker(tasks <-chan *TaskResource) {
 	for task := range tasks {
-		// // recover from panic, capture error and report
-		// defer func() {
-		// 	if err := recover(); err != nil {
-		// 		recordError(task, err.(error))
-		// 	}
-		// }()
+		// recover from panic, capture error and report
+		defer func() {
+			if err := recover(); err != nil {
+				recordError(task, err.(error))
+			}
+		}()
 
 		action := task.ToAction().initialize(s.core)
 

--- a/hack/deploy_jenkins.sh
+++ b/hack/deploy_jenkins.sh
@@ -1,0 +1,38 @@
+curl -XPOST localhost:8080/v0/entrypoints -d '{
+  "domain": "example.com"
+}' || true
+
+curl -XPOST localhost:8080/v0/apps -d '{
+  "name": "jenkins"
+}'
+
+curl -XPOST localhost:8080/v0/apps/jenkins/components -d '{
+  "name": "jenkins"
+}'
+
+curl -XPOST localhost:8080/v0/apps/jenkins/components/jenkins/releases -d '{
+  "containers": [
+    {
+      "image": "jenkins",
+      "cpu": {
+        "min": 0,
+        "max": 0
+      },
+      "ram": {
+        "min": 0,
+        "max": 0
+      },
+      "ports": [
+        {
+          "protocol": "HTTP",
+          "number": 8080,
+          "external_number": 33666,
+          "public": true,
+          "entrypoint_domain": "example.com"
+        }
+      ]
+    }
+  ]
+}'
+
+curl -XPOST localhost:8080/v0/apps/jenkins/components/jenkins/deploy


### PR DESCRIPTION
While recovering from a panic in the background makes spotting bugs a
little trickier--mainly because we're missing backtrace (which I assume
could be added)--it prevents lingering RUNNING tasks after panics, which
make using the API very difficult.