### PR TITLE
Fix Release update bug

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -52,6 +52,9 @@
 
 ## v0.7.x
 
+* volume names should have full resource path, and most other cloud assets
+  should have a unique prefix for the whole Supergiant install
+
 * cancel / revert deploys
 
 ## v0.8.x

--- a/api/app_controller.go
+++ b/api/app_controller.go
@@ -71,7 +71,7 @@ func (c *AppController) Update(w http.ResponseWriter, r *http.Request) {
 
 	core.ZeroReadonlyFields(app)
 
-	if err := app.Update(); err != nil {
+	if err := app.Patch(); err != nil {
 		renderError(w, err, http.StatusInternalServerError)
 		return
 	}

--- a/api/component_controller.go
+++ b/api/component_controller.go
@@ -81,7 +81,7 @@ func (c *ComponentController) Update(w http.ResponseWriter, r *http.Request) {
 
 	core.ZeroReadonlyFields(component)
 
-	if err := component.Update(); err != nil {
+	if err := component.Patch(); err != nil {
 		renderError(w, err, http.StatusInternalServerError)
 		return
 	}

--- a/api/entrypoint_controller.go
+++ b/api/entrypoint_controller.go
@@ -71,7 +71,7 @@ func (c *EntrypointController) Update(w http.ResponseWriter, r *http.Request) {
 
 	core.ZeroReadonlyFields(entrypoint)
 
-	if err := entrypoint.Update(); err != nil {
+	if err := entrypoint.Patch(); err != nil {
 		renderError(w, err, http.StatusInternalServerError)
 		return
 	}

--- a/api/image_repo_controller.go
+++ b/api/image_repo_controller.go
@@ -80,7 +80,7 @@ func (c *ImageRepoController) Update(w http.ResponseWriter, r *http.Request) {
 
 	core.ZeroReadonlyFields(repo)
 
-	if err := repo.Update(); err != nil {
+	if err := repo.Patch(); err != nil {
 		renderError(w, err, http.StatusInternalServerError)
 		return
 	}

--- a/api/node_controller.go
+++ b/api/node_controller.go
@@ -71,7 +71,7 @@ func (c *NodeController) Update(w http.ResponseWriter, r *http.Request) {
 
 	core.ZeroReadonlyFields(node)
 
-	if err := node.Update(); err != nil {
+	if err := node.Patch(); err != nil {
 		renderError(w, err, http.StatusInternalServerError)
 		return
 	}

--- a/api/release_controller.go
+++ b/api/release_controller.go
@@ -112,7 +112,7 @@ func (c *ReleaseController) Update(w http.ResponseWriter, r *http.Request) {
 
 	core.ZeroReadonlyFields(release)
 
-	if err := release.Update(); err != nil {
+	if err := release.Patch(); err != nil {
 		renderError(w, err, http.StatusInternalServerError)
 		return
 	}

--- a/common/types.go
+++ b/common/types.go
@@ -26,7 +26,7 @@ type Component struct {
 // both "definitions" that create "instances" of the real thing
 type Release struct {
 	// NOTE Timestamp here does not use the Timestamp type.
-	Timestamp ID `json:"timestamp" sg:"readonly"`
+	Timestamp ID `json:"timestamp"`
 
 	// TODO
 	// InstanceGroup is used as a labeling mechanism for instances. If nil,
@@ -98,7 +98,7 @@ type Entrypoint struct {
 }
 
 type Task struct {
-	ID         ID     `json:"id" sg:"readonly"`
+	ID         ID     `json:"id"`
 	ActionData string `json:"action_data" validate:"nonzero"`
 
 	MaxAttempts int `json:"max_attempts" validate:"min=1" sg:"default=10"`
@@ -127,7 +127,7 @@ type ImageRepo struct {
 }
 
 type Node struct {
-	ID   ID     `json:"id" sg:"readonly"`
+	ID   ID     `json:"id"`
 	Name string `json:"name" sg:"readonly"`
 	// This is the only input for Node
 	Class      string `json:"class" validate:"nonzero"`
@@ -186,7 +186,7 @@ type VolumeBlueprint struct {
 
 type ContainerBlueprint struct {
 	Image   string         `json:"image" validate:"nonzero,regexp=^[-\\w\\.\\/]+(:[-\\w\\.]+)?$"`
-	Name    string         `json:"name,omitempty"` // TODO can we do regex validations, that only fire if the value is provided? (i.e. not-nonzero)
+	Name    string         `json:"name,omitempty" validate:"regexp=^[-\\w\\.\\/]+(:[-\\w\\.]+)?$"`
 	Command []string       `json:"command,omitempty"`
 	Ports   []*Port        `json:"ports,omitempty"`
 	Env     []*EnvVar      `json:"env,omitempty"`

--- a/core/app_test.go
+++ b/core/app_test.go
@@ -125,22 +125,10 @@ func TestAppUpdate(t *testing.T) {
 	Convey("Given an AppCollection with an AppResource", t, func() {
 		etcdKeyUpdated := ""
 
-		fakeEtcd := new(mock.FakeEtcd)
-
-		fakeEtcd.OnUpdate(func(key string, val string) error {
+		fakeEtcd := new(mock.FakeEtcd).OnUpdate(func(key string, val string) error {
 			etcdKeyUpdated = key
 			return nil
 		})
-
-		fakeEtcd.ReturnValueOnGet(
-			`{
-				"name": "test",
-				"created": "Tue, 12 Apr 2016 03:54:56 UTC",
-				"updated": null,
-				"tags": {}
-			}`,
-			nil,
-		)
 
 		core := newMockCore(fakeEtcd)
 		apps := core.Apps()
@@ -254,6 +242,7 @@ type FakeComponentCollection struct {
 	CreateFn func() error
 	GetFn    func() (*ComponentResource, error)
 	UpdateFn func() error
+	PatchFn  func() error
 	DeleteFn func(Resource) error
 	DeployFn func(Resource) error
 }
@@ -280,6 +269,10 @@ func (f *FakeComponentCollection) Get(common.ID) (*ComponentResource, error) {
 
 func (f *FakeComponentCollection) Update(common.ID, *ComponentResource) error {
 	return f.UpdateFn()
+}
+
+func (f *FakeComponentCollection) Patch(common.ID, *ComponentResource) error {
+	return f.PatchFn()
 }
 
 func (f *FakeComponentCollection) Delete(r Resource) error {

--- a/core/component_test.go
+++ b/core/component_test.go
@@ -113,23 +113,10 @@ func TestComponentUpdate(t *testing.T) {
 	Convey("Given an ComponentCollection with an ComponentResource", t, func() {
 		etcdKeyUpdated := ""
 
-		fakeEtcd := new(mock.FakeEtcd)
-
-		fakeEtcd.OnUpdate(func(key string, val string) error {
+		fakeEtcd := new(mock.FakeEtcd).OnUpdate(func(key string, val string) error {
 			etcdKeyUpdated = key
 			return nil
 		})
-
-		// Update uses patch, which first performs a Get
-		fakeEtcd.ReturnValueOnGet(
-			`{
-				"name": "component-test",
-				"created": "Tue, 12 Apr 2016 03:54:56 UTC",
-				"updated": null,
-				"tags": {}
-			}`,
-			nil,
-		)
 
 		core := newMockCore(fakeEtcd)
 
@@ -232,6 +219,7 @@ type FakeReleaseCollection struct {
 	MergeCreateFn func() error
 	GetFn         func() (*ReleaseResource, error)
 	UpdateFn      func() error
+	PatchFn       func() error
 	DeleteFn      func(*ReleaseResource) error
 }
 
@@ -261,6 +249,10 @@ func (f *FakeReleaseCollection) Get(common.ID) (*ReleaseResource, error) {
 
 func (f *FakeReleaseCollection) Update(common.ID, *ReleaseResource) error {
 	return f.UpdateFn()
+}
+
+func (f *FakeReleaseCollection) Patch(common.ID, *ReleaseResource) error {
+	return f.PatchFn()
 }
 
 func (f *FakeReleaseCollection) Delete(r *ReleaseResource) error {

--- a/core/core.go
+++ b/core/core.go
@@ -1,6 +1,8 @@
 package core
 
 import (
+	"fmt"
+
 	"github.com/Sirupsen/logrus"
 	"github.com/supergiant/guber"
 	"github.com/supergiant/supergiant/common"
@@ -114,7 +116,7 @@ func (c *Core) child(key string) (l Locatable) {
 	case "tasks":
 		l = c.Tasks().(Locatable)
 	default:
-		Log.Panicf("No child with key %s for %T", key, c)
+		panic(fmt.Errorf("No child with key %s for %T", key, c))
 	}
 	return
 }

--- a/core/entrypoint.go
+++ b/core/entrypoint.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/supergiant/supergiant/common"
@@ -16,6 +17,7 @@ type EntrypointsInterface interface {
 	Create(*EntrypointResource) error
 	Get(common.ID) (*EntrypointResource, error)
 	Update(common.ID, *EntrypointResource) error
+	Patch(common.ID, *EntrypointResource) error
 	Delete(*EntrypointResource) error
 }
 
@@ -96,7 +98,12 @@ func (c *EntrypointCollection) Get(domain common.ID) (*EntrypointResource, error
 
 // Update saves the Entrypoint in etcd through an update.
 func (c *EntrypointCollection) Update(domain common.ID, r *EntrypointResource) error {
-	return c.core.db.patch(c, domain, r)
+	return c.core.db.update(c, domain, r)
+}
+
+// Patch partially updates the App in etcd.
+func (c *EntrypointCollection) Patch(name common.ID, r *EntrypointResource) error {
+	return c.core.db.patch(c, name, r)
 }
 
 // Delete cascades deletes to all Components, deletes the Kube Namespace, and
@@ -127,7 +134,7 @@ func (c *EntrypointCollection) parent() (l Locatable) {
 func (c *EntrypointCollection) child(key string) Locatable {
 	r, err := c.Get(common.IDString(key))
 	if err != nil {
-		Log.Panicf("No child with key %s for %T", key, c)
+		panic(fmt.Errorf("No child with key %s for %T", key, c))
 	}
 	return r
 }
@@ -146,24 +153,23 @@ func (r *EntrypointResource) parent() Locatable {
 func (r *EntrypointResource) child(key string) (l Locatable) {
 	switch key {
 	default:
-		Log.Panicf("No child with key %s for %T", key, r)
+		panic(fmt.Errorf("No child with key %s for %T", key, r))
 	}
-	return
 }
 
 // Action implements the Resource interface.
 func (r *EntrypointResource) Action(name string) *Action {
-	var fn ActionPerformer
+	// var fn ActionPerformer
 	switch name {
 	default:
-		Log.Panicf("No action %s for Entrypoint", name)
+		panic(fmt.Errorf("No action %s for Entrypoint", name))
 	}
-	return &Action{
-		ActionName: name,
-		core:       r.core,
-		resource:   r,
-		performer:  fn,
-	}
+	// return &Action{
+	// 	ActionName: name,
+	// 	core:       r.core,
+	// 	resource:   r,
+	// 	performer:  fn,
+	// }
 }
 
 //------------------------------------------------------------------------------
@@ -176,6 +182,11 @@ func (r *EntrypointResource) decorate() (err error) {
 // Update is a proxy method to EntrypointCollection's Update.
 func (r *EntrypointResource) Update() error {
 	return r.collection.Update(r.Domain, r)
+}
+
+// Patch is a proxy method to collection Patch.
+func (r *EntrypointResource) Patch() error {
+	return r.collection.Patch(r.Domain, r)
 }
 
 // Delete is a proxy method to EntrypointCollection's Delete.

--- a/core/entrypoint_test.go
+++ b/core/entrypoint_test.go
@@ -165,22 +165,10 @@ func TestEntrypointUpdate(t *testing.T) {
 	Convey("Given an EntrypointCollection with an EntrypointResource", t, func() {
 		etcdKeyUpdated := ""
 
-		fakeEtcd := new(mock.FakeEtcd)
-
-		fakeEtcd.OnUpdate(func(key string, val string) error {
+		fakeEtcd := new(mock.FakeEtcd).OnUpdate(func(key string, val string) error {
 			etcdKeyUpdated = key
 			return nil
 		})
-
-		fakeEtcd.ReturnValueOnGet(
-			`{
-				"domain": "example.com",
-				"created": "Tue, 12 Apr 2016 03:54:56 UTC",
-				"updated": null,
-				"tags": {}
-			}`,
-			nil,
-		)
 
 		core := newMockCore(fakeEtcd)
 		entrypoints := core.Entrypoints()

--- a/core/image_registry.go
+++ b/core/image_registry.go
@@ -1,6 +1,10 @@
 package core
 
-import "github.com/supergiant/supergiant/common"
+import (
+	"fmt"
+
+	"github.com/supergiant/supergiant/common"
+)
 
 type ImageRegistriesInterface interface {
 	List() (*ImageRegistryList, error)
@@ -8,6 +12,7 @@ type ImageRegistriesInterface interface {
 	Create(*ImageRegistryResource) error
 	Get(common.ID) (*ImageRegistryResource, error)
 	Update(common.ID, *ImageRegistryResource) error
+	Patch(common.ID, *ImageRegistryResource) error
 	Delete(*ImageRegistryResource) error
 }
 
@@ -75,6 +80,11 @@ func (c *ImageRegistryCollection) Get(name common.ID) (*ImageRegistryResource, e
 
 // Update updates the ImageRegistry in etcd.
 func (c *ImageRegistryCollection) Update(name common.ID, r *ImageRegistryResource) error {
+	return c.core.db.update(c, name, r)
+}
+
+// Patch partially updates the App in etcd.
+func (c *ImageRegistryCollection) Patch(name common.ID, r *ImageRegistryResource) error {
 	return c.core.db.patch(c, name, r)
 }
 
@@ -99,7 +109,7 @@ func (c *ImageRegistryCollection) parent() (l Locatable) {
 func (c *ImageRegistryCollection) child(key string) Locatable {
 	r, err := c.Get(common.IDString(key))
 	if err != nil {
-		Log.Panicf("No child with key %s for %T", key, c)
+		panic(fmt.Errorf("No child with key %s for %T", key, c))
 	}
 	return r
 }
@@ -120,24 +130,24 @@ func (r *ImageRegistryResource) child(key string) (l Locatable) {
 	case "repos":
 		l = r.ImageRepos().(Locatable)
 	default:
-		Log.Panicf("No child with key %s for %T", key, r)
+		panic(fmt.Errorf("No child with key %s for %T", key, r))
 	}
 	return
 }
 
 // Action implements the Resource interface.
 func (r *ImageRegistryResource) Action(name string) *Action {
-	var fn ActionPerformer
+	// var fn ActionPerformer
 	switch name {
 	default:
-		Log.Panicf("No action %s for ImageRegistry", name)
+		panic(fmt.Errorf("No action %s for ImageRegistry", name))
 	}
-	return &Action{
-		ActionName: name,
-		core:       r.core,
-		resource:   r,
-		performer:  fn,
-	}
+	// return &Action{
+	// 	ActionName: name,
+	// 	core:       r.core,
+	// 	resource:   r,
+	// 	performer:  fn,
+	// }
 }
 
 //------------------------------------------------------------------------------
@@ -150,6 +160,11 @@ func (r *ImageRegistryResource) decorate() (err error) {
 // Update is a proxy method to ImageRegistryCollection's Update.
 func (r *ImageRegistryResource) Update() error {
 	return r.collection.Update(r.Name, r)
+}
+
+// Patch is a proxy method to collection Patch.
+func (r *ImageRegistryResource) Patch() error {
+	return r.collection.Patch(r.Name, r)
 }
 
 // Delete is a proxy method to ImageRegistryCollection's Delete.

--- a/core/image_repo.go
+++ b/core/image_repo.go
@@ -1,6 +1,10 @@
 package core
 
-import "github.com/supergiant/supergiant/common"
+import (
+	"fmt"
+
+	"github.com/supergiant/supergiant/common"
+)
 
 type ImageReposInterface interface {
 	List() (*ImageRepoList, error)
@@ -8,6 +12,7 @@ type ImageReposInterface interface {
 	Create(*ImageRepoResource) error
 	Get(common.ID) (*ImageRepoResource, error)
 	Update(common.ID, *ImageRepoResource) error
+	Patch(common.ID, *ImageRepoResource) error
 	Delete(*ImageRepoResource) error
 }
 
@@ -69,6 +74,11 @@ func (c *ImageRepoCollection) Get(name common.ID) (*ImageRepoResource, error) {
 
 // Update updates the ImageRepo in etcd.
 func (c *ImageRepoCollection) Update(name common.ID, r *ImageRepoResource) error {
+	return c.core.db.update(c, name, r)
+}
+
+// Patch partially updates the App in etcd.
+func (c *ImageRepoCollection) Patch(name common.ID, r *ImageRepoResource) error {
 	return c.core.db.patch(c, name, r)
 }
 
@@ -93,7 +103,7 @@ func (c *ImageRepoCollection) parent() Locatable {
 func (c *ImageRepoCollection) child(key string) Locatable {
 	r, err := c.Get(common.IDString(key))
 	if err != nil {
-		Log.Panicf("No child with key %s for %T", key, c)
+		panic(fmt.Errorf("No child with key %s for %T", key, c))
 	}
 	return r
 }
@@ -112,24 +122,23 @@ func (r *ImageRepoResource) parent() Locatable {
 func (r *ImageRepoResource) child(key string) (l Locatable) {
 	switch key {
 	default:
-		Log.Panicf("No child with key %s for %T", key, r)
+		panic(fmt.Errorf("No child with key %s for %T", key, r))
 	}
-	return
 }
 
 // Action implements the Resource interface.
 func (r *ImageRepoResource) Action(name string) *Action {
-	var fn ActionPerformer
+	// var fn ActionPerformer
 	switch name {
 	default:
-		Log.Panicf("No action %s for ImageRepo", name)
+		panic(fmt.Errorf("No action %s for ImageRepo", name))
 	}
-	return &Action{
-		ActionName: name,
-		core:       r.core,
-		resource:   r,
-		performer:  fn,
-	}
+	// return &Action{
+	// 	ActionName: name,
+	// 	core:       r.core,
+	// 	resource:   r,
+	// 	performer:  fn,
+	// }
 }
 
 //------------------------------------------------------------------------------
@@ -142,6 +151,11 @@ func (r *ImageRepoResource) decorate() (err error) {
 // Update is a proxy method to ImageRepoCollection's Update.
 func (r *ImageRepoResource) Update() error {
 	return r.collection.Update(r.Name, r)
+}
+
+// Patch is a proxy method to collection Patch.
+func (r *ImageRepoResource) Patch() error {
+	return r.collection.Patch(r.Name, r)
 }
 
 // Delete is a proxy method to ImageRepoCollection's Delete.

--- a/core/image_repo_test.go
+++ b/core/image_repo_test.go
@@ -106,23 +106,10 @@ func TestImageRepoUpdate(t *testing.T) {
 	Convey("Given an ImageRepoCollection with an ImageRepoResource", t, func() {
 		etcdKeyUpdated := ""
 
-		fakeEtcd := new(mock.FakeEtcd)
-
-		fakeEtcd.OnUpdate(func(key string, val string) error {
+		fakeEtcd := new(mock.FakeEtcd).OnUpdate(func(key string, val string) error {
 			etcdKeyUpdated = key
 			return nil
 		})
-
-		fakeEtcd.ReturnValueOnGet(
-			`{
-				"name": "test",
-				"key": "key",
-				"created": "Tue, 12 Apr 2016 03:54:56 UTC",
-				"updated": null,
-				"tags": {}
-			}`,
-			nil,
-		)
 
 		core := newMockCore(fakeEtcd)
 		repos := core.ImageRepos()

--- a/core/instance.go
+++ b/core/instance.go
@@ -131,7 +131,7 @@ func (c *InstanceCollection) parent() Locatable {
 func (c *InstanceCollection) child(key string) Locatable {
 	r, err := c.Get(common.IDString(key))
 	if err != nil {
-		Log.Panicf("No child with key %s for %T", key, c)
+		panic(fmt.Errorf("No child with key %s for %T", key, c))
 	}
 	return r
 }
@@ -150,9 +150,8 @@ func (r *InstanceResource) parent() Locatable {
 func (r *InstanceResource) child(key string) (l Locatable) {
 	switch key {
 	default:
-		Log.Panicf("No child with key %s for %T", key, r)
+		panic(fmt.Errorf("No child with key %s for %T", key, r))
 	}
-	return
 }
 
 // Action implements the Resource interface.
@@ -164,7 +163,7 @@ func (r *InstanceResource) Action(name string) *Action {
 	case "stop":
 		fn = ActionPerformer(r.collection.Stop)
 	default:
-		Log.Panicf("No action %s for Instance", name)
+		panic(fmt.Errorf("No action %s for Instance", name))
 	}
 	return &Action{
 		ActionName: name,

--- a/core/kube_helpers.go
+++ b/core/kube_helpers.go
@@ -172,9 +172,9 @@ func asKubeSecret(m *ImageRepoResource) *guber.Secret {
 		Metadata: &guber.Metadata{
 			Name: common.StringID(m.Name),
 		},
-		Type: "kubernetes.io/dockercfg",
+		Type: "kubernetes.io/dockerconfigjson",
 		Data: map[string]string{
-			".dockercfg": m.Key,
+			".dockerconfigjson": m.Key,
 		},
 	}
 }
@@ -183,7 +183,9 @@ func asKubeSecret(m *ImageRepoResource) *guber.Secret {
 func totalCpuLimit(pod *guber.Pod) *common.CoresValue {
 	cores := new(common.CoresValue)
 	for _, container := range pod.Spec.Containers {
-		cores.Millicores += common.CoresFromString(container.Resources.Limits.CPU).Millicores
+		if container.Resources != nil && container.Resources.Limits != nil {
+			cores.Millicores += common.CoresFromString(container.Resources.Limits.CPU).Millicores
+		}
 	}
 	return cores
 }
@@ -191,7 +193,9 @@ func totalCpuLimit(pod *guber.Pod) *common.CoresValue {
 func totalRamLimit(pod *guber.Pod) *common.BytesValue {
 	bytes := new(common.BytesValue)
 	for _, container := range pod.Spec.Containers {
-		bytes.Bytes += common.BytesFromString(container.Resources.Limits.Memory).Bytes
+		if container.Resources != nil && container.Resources.Limits != nil {
+			bytes.Bytes += common.BytesFromString(container.Resources.Limits.Memory).Bytes
+		}
 	}
 	return bytes
 }

--- a/core/node.go
+++ b/core/node.go
@@ -31,6 +31,7 @@ type NodesInterface interface {
 	Create(*NodeResource) error
 	Get(common.ID) (*NodeResource, error)
 	Update(common.ID, *NodeResource) error
+	Patch(common.ID, *NodeResource) error
 	Delete(*NodeResource) error
 }
 
@@ -114,7 +115,12 @@ func (c *NodeCollection) Get(id common.ID) (*NodeResource, error) {
 
 // Update updates the Node in etcd.
 func (c *NodeCollection) Update(id common.ID, r *NodeResource) error {
-	return c.core.db.patch(c, id, r)
+	return c.core.db.update(c, id, r)
+}
+
+// Patch partially updates the App in etcd.
+func (c *NodeCollection) Patch(name common.ID, r *NodeResource) error {
+	return c.core.db.patch(c, name, r)
 }
 
 // Delete deletes the Node in etcd.
@@ -187,7 +193,7 @@ func (c *NodeCollection) parent() (l Locatable) {
 func (c *NodeCollection) child(key string) Locatable {
 	r, err := c.Get(common.IDString(key))
 	if err != nil {
-		Log.Panicf("No child with key %s for %T", key, c)
+		panic(fmt.Errorf("No child with key %s for %T", key, c))
 	}
 	return r
 }
@@ -206,24 +212,23 @@ func (r *NodeResource) parent() Locatable {
 func (r *NodeResource) child(key string) (l Locatable) {
 	switch key {
 	default:
-		Log.Panicf("No child with key %s for %T", key, r)
+		panic(fmt.Errorf("No child with key %s for %T", key, r))
 	}
-	return
 }
 
 // Action implements the Resource interface.
 func (r *NodeResource) Action(name string) *Action {
-	var fn ActionPerformer
+	// var fn ActionPerformer
 	switch name {
 	default:
-		Log.Panicf("No action %s for Node", name)
+		panic(fmt.Errorf("No action %s for Node", name))
 	}
-	return &Action{
-		ActionName: name,
-		core:       r.core,
-		resource:   r,
-		performer:  fn,
-	}
+	// return &Action{
+	// 	ActionName: name,
+	// 	core:       r.core,
+	// 	resource:   r,
+	// 	performer:  fn,
+	// }
 }
 
 //------------------------------------------------------------------------------
@@ -274,6 +279,11 @@ func (r *NodeResource) decorate() error {
 // Update is a proxy method to NodeCollection's Update.
 func (r *NodeResource) Update() error {
 	return r.collection.Update(r.ID, r)
+}
+
+// Patch is a proxy method to collection Patch.
+func (r *NodeResource) Patch() error {
+	return r.collection.Patch(r.ID, r)
 }
 
 // Delete is a proxy method to NodeCollection's Delete.

--- a/hack/deploy_cms.sh
+++ b/hack/deploy_cms.sh
@@ -1,0 +1,93 @@
+set -e
+
+curl -XPOST localhost:8080/v0/registries/dockerhub/repos -d '{
+  "name": "supergiant",
+  "key": "'$SUPERGIANT_DOCKERHUB_KEY'"
+}' || true
+
+curl -XPOST localhost:8080/v0/entrypoints -d '{
+  "domain": "example.com"
+}' || true
+
+curl -XPOST localhost:8080/v0/apps -d '{
+  "name": "supergiant-io"
+}'
+
+curl -XPOST localhost:8080/v0/apps/supergiant-io/components -d '{
+  "name": "mysql"
+}'
+
+curl -XPOST localhost:8080/v0/apps/supergiant-io/components/mysql/releases -d '{
+  "containers": [
+    {
+      "image": "mysql/mysql-server",
+      "ports": [
+        {
+          "protocol": "TCP",
+          "number": 3306
+        }
+      ],
+      "env": [
+        {
+          "name": "MYSQL_DATABASE",
+          "value": "'$MYSQL_DATABASE'"
+        },
+        {
+          "name": "MYSQL_ROOT_PASSWORD",
+          "value": "'$MYSQL_ROOT_PASSWORD'"
+        },
+        {
+          "name": "MYSQL_USER",
+          "value": "'$MYSQL_USER'"
+        },
+        {
+          "name": "MYSQL_PASSWORD",
+          "value": "'$MYSQL_PASSWORD'"
+        }
+      ]
+    }
+  ]
+}'
+
+curl -XPOST localhost:8080/v0/apps/supergiant-io/components/mysql/deploy
+
+curl -XPOST localhost:8080/v0/apps/supergiant-io/components -d '{
+  "name": "craft"
+}'
+
+curl -XPOST localhost:8080/v0/apps/supergiant-io/components/craft/releases -d '{
+  "containers": [
+    {
+      "image": "supergiant/supergiant-cms:docker",
+      "ports": [
+        {
+          "protocol": "HTTP",
+          "number": 80,
+          "external_number": 35555,
+          "public": true,
+          "entrypoint_domain": "example.com"
+        }
+      ],
+      "env": [
+        {
+          "name": "CRAFT_DB_SERVER",
+          "value": "mysql.supergiant-io.svc.cluster.local"
+        },
+        {
+          "name": "CRAFT_DB_USER",
+          "value": "'$MYSQL_USER'"
+        },
+        {
+          "name": "CRAFT_DB_PASSWORD",
+          "value": "'$MYSQL_PASSWORD'"
+        },
+        {
+          "name": "CRAFT_DB_NAME",
+          "value": "'$MYSQL_DATABASE'"
+        }
+      ]
+    }
+  ]
+}'
+
+curl -XPOST localhost:8080/v0/apps/supergiant-io/components/craft/deploy


### PR DESCRIPTION
- add Patch method on resources, revert Update to use actual update, so
  that core/ has access to both
- Remove readonly from Release and Task IDs -- readonly is not needed on
  ID fields, and causes nil pointer with updates due to zeroing readonly
  fields
- add validation to container name to match Kubernetes
- change Log.Panics to normal panics for recover in Supervisor
- fix nil pointer bug with totalCpuLimit and totalRamLimit

_Note: this is actually for 0.5.10, despite the incorrect branch name._