### PR TITLE
Add CRUD tests for Releases, fix overwriting default bug

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -14,7 +14,7 @@ type Component struct {
 
 	CustomDeployScript *CustomDeployScript `json:"custom_deploy_script"`
 
-	CurrentReleaseTimestamp ID `json:"current_release_id" sg:"readonly"`
+	CurrentReleaseTimestamp ID `json:"current_release_id" sg:"readonly"` // TODO this should be release_timestamp, not release_id
 	TargetReleaseTimestamp  ID `json:"target_release_id" sg:"readonly"`
 
 	Addresses *ComponentAddresses `json:"addresses,omitempty" sg:"readonly,nostore"`

--- a/core/action.go
+++ b/core/action.go
@@ -19,7 +19,7 @@ type Action struct {
 }
 
 // initialize takes a *Core, and loads resource and performer on the Action.
-// It is used by Supervisor when retrying a Task loaded from the DB.
+// It is used by Supervisor when retrying a Task loaded from the db.
 // It returns the *Action purely for the sake of doing initialize(c).Perform()
 func (a *Action) initialize(c *Core) *Action {
 	a.core = c

--- a/core/app.go
+++ b/core/app.go
@@ -22,9 +22,9 @@ type AppCollection struct {
 }
 
 type AppResource struct {
-	core       *Core
-	collection *AppCollection
 	*common.App
+	collection *AppCollection
+	core       *Core
 
 	// Relations
 	ComponentsInterface ComponentsInterface `json:"-"`
@@ -39,8 +39,8 @@ type AppList struct {
 // initializeResource implements the Collection interface.
 func (c *AppCollection) initializeResource(in Resource) {
 	r := in.(*AppResource)
-	r.collection = c
 	r.core = c.core
+	r.collection = c
 	r.ComponentsInterface = &ComponentCollection{
 		core: c.core,
 		app:  r,

--- a/core/aws_meta.go
+++ b/core/aws_meta.go
@@ -26,15 +26,15 @@ func checkForAWSMeta(c *Core) {
 			Log.Info("AWS AZ Detected,", c.AwsAZ)
 		}
 	}
-	if c.AwsSgID == "" {
-		sg, err := getAWSSecurityGroupID()
-		if err != nil {
-			Log.Error(err)
-		} else {
-			c.AwsSgID = sg
-			Log.Info("AWS Security Group Detected,", c.AwsSgID)
-		}
-	}
+	// if c.AwsSgID == "" {
+	// 	sg, err := getAWSSecurityGroupID()
+	// 	if err != nil {
+	// 		Log.Error(err)
+	// 	} else {
+	// 		c.AwsSgID = sg
+	// 		Log.Info("AWS Security Group Detected,", c.AwsSgID)
+	// 	}
+	// }
 	if c.AwsSubnetID == "" {
 		sub, err := getAWSSubnetID()
 		if err != nil {
@@ -101,33 +101,33 @@ func getAWSAZ() (string, error) {
 	return az, nil
 }
 
-func getAWSSecurityGroupID() (string, error) {
-	mac, err := getMacs()
-	if err != nil {
-		return "", err
-	}
-	secgr, err := http.Get("http://169.254.169.254/latest/meta-data/network/interfaces/macs/" + mac + "/security-group-ids")
-	if err != nil {
-		return "", err
-	}
-	defer secgr.Body.Close()
-
-	sglen, err := secgr.Body.Read(nil)
-	if err != nil {
-		return "", err
-	}
-	if sglen > 1 {
-		return "", errors.New("More than one security group detected. Cannot determine security group. Please specify manually.")
-	}
-
-	sgidbyte, err := ioutil.ReadAll(secgr.Body)
-	if err != nil {
-		return "", err
-	}
-
-	sgid := string(sgidbyte)
-	return sgid, nil
-}
+// func getAWSSecurityGroupID() (string, error) {
+// 	mac, err := getMacs()
+// 	if err != nil {
+// 		return "", err
+// 	}
+// 	secgr, err := http.Get("http://169.254.169.254/latest/meta-data/network/interfaces/macs/" + mac + "/security-group-ids")
+// 	if err != nil {
+// 		return "", err
+// 	}
+// 	defer secgr.Body.Close()
+//
+// 	sglen, err := secgr.Body.Read(nil)
+// 	if err != nil {
+// 		return "", err
+// 	}
+// 	if sglen > 1 {
+// 		return "", errors.New("More than one security group detected. Cannot determine security group. Please specify manually.")
+// 	}
+//
+// 	sgidbyte, err := ioutil.ReadAll(secgr.Body)
+// 	if err != nil {
+// 		return "", err
+// 	}
+//
+// 	sgid := string(sgidbyte)
+// 	return sgid, nil
+// }
 
 func getAWSSubnetID() (string, error) {
 	mac, err := getMacs()

--- a/core/component.go
+++ b/core/component.go
@@ -45,9 +45,11 @@ func (c *ComponentCollection) initializeResource(in Resource) {
 	r := in.(*ComponentResource)
 	r.collection = c
 	r.core = c.core
-	r.ReleasesInterface = &ReleaseCollection{
-		core:      c.core,
-		component: r,
+	if r.ReleasesInterface == nil { // don't want to reset for testing purposes
+		r.ReleasesInterface = &ReleaseCollection{
+			core:      c.core,
+			component: r,
+		}
 	}
 }
 

--- a/core/component_test.go
+++ b/core/component_test.go
@@ -165,7 +165,7 @@ func TestComponentDelete(t *testing.T) {
 			core:      core,
 		}
 
-		fakeReleases.ReturnValuesOnGet([]*common.Release{
+		fakeReleases.ReturnValuesOnList([]*common.Release{
 			&common.Release{
 				Timestamp: common.IDString("20160412035456"),
 			},
@@ -189,77 +189,4 @@ func TestComponentDelete(t *testing.T) {
 			})
 		})
 	})
-}
-
-// Mock
-
-func (f *FakeReleaseCollection) ReturnValuesOnGet(components []*common.Release) *FakeReleaseCollection {
-	var items []*ReleaseResource
-	for _, component := range components {
-		items = append(items, &ReleaseResource{
-			core:       f.core,
-			collection: f,
-			Release:    component,
-		})
-	}
-	f.ListFn = func() (*ReleaseList, error) {
-		return &ReleaseList{Items: items}, nil
-	}
-	return f
-}
-
-func (f *FakeReleaseCollection) OnDelete(clbk func(*ReleaseResource) error) *FakeReleaseCollection {
-	f.DeleteFn = func(r *ReleaseResource) error {
-		return clbk(r)
-	}
-	return f
-}
-
-type FakeReleaseCollection struct {
-	core          *Core
-	component     *ComponentResource
-	ListFn        func() (*ReleaseList, error)
-	NewFn         func() *ReleaseResource
-	CreateFn      func() error
-	MergeCreateFn func() error
-	GetFn         func() (*ReleaseResource, error)
-	UpdateFn      func() error
-	PatchFn       func() error
-	DeleteFn      func(*ReleaseResource) error
-}
-
-func (f *FakeReleaseCollection) Component() *ComponentResource {
-	return f.component
-}
-
-func (f *FakeReleaseCollection) List() (*ReleaseList, error) {
-	return f.ListFn()
-}
-
-func (f *FakeReleaseCollection) New() *ReleaseResource {
-	return f.NewFn()
-}
-
-func (f *FakeReleaseCollection) Create(*ReleaseResource) error {
-	return f.CreateFn()
-}
-
-func (f *FakeReleaseCollection) MergeCreate(*ReleaseResource) error {
-	return f.MergeCreateFn()
-}
-
-func (f *FakeReleaseCollection) Get(common.ID) (*ReleaseResource, error) {
-	return f.GetFn()
-}
-
-func (f *FakeReleaseCollection) Update(common.ID, *ReleaseResource) error {
-	return f.UpdateFn()
-}
-
-func (f *FakeReleaseCollection) Patch(common.ID, *ReleaseResource) error {
-	return f.PatchFn()
-}
-
-func (f *FakeReleaseCollection) Delete(r *ReleaseResource) error {
-	return f.DeleteFn(r)
 }

--- a/core/component_test.go
+++ b/core/component_test.go
@@ -24,6 +24,7 @@ func TestComponentList(t *testing.T) {
 		)
 		core := newMockCore(fakeEtcd)
 
+		core.AppsInterface = &AppCollection{core}
 		app := core.Apps().New()
 		app.Name = common.IDString("test")
 
@@ -56,6 +57,7 @@ func TestComponentCreate(t *testing.T) {
 
 		core := newMockCore(fakeEtcd)
 
+		core.AppsInterface = &AppCollection{core}
 		app := core.Apps().New()
 		app.Name = common.IDString("test")
 
@@ -89,6 +91,7 @@ func TestComponentGet(t *testing.T) {
 		)
 		core := newMockCore(fakeEtcd)
 
+		core.AppsInterface = &AppCollection{core}
 		app := core.Apps().New()
 		app.Name = common.IDString("test")
 
@@ -120,6 +123,7 @@ func TestComponentUpdate(t *testing.T) {
 
 		core := newMockCore(fakeEtcd)
 
+		core.AppsInterface = &AppCollection{core}
 		app := core.Apps().New()
 		app.Name = common.IDString("test")
 
@@ -149,6 +153,7 @@ func TestComponentDelete(t *testing.T) {
 		})
 		core := newMockCore(fakeEtcd)
 
+		core.AppsInterface = &AppCollection{core}
 		app := core.Apps().New()
 		app.Name = common.IDString("test")
 

--- a/core/core.go
+++ b/core/core.go
@@ -90,6 +90,15 @@ func (c *Core) Initialize() {
 	c.elb = elb.New(awsSession, awsConf)
 	c.autoscaling = autoscaling.New(awsSession, awsConf)
 
+	c.AppsInterface = &AppCollection{c}
+	c.EntrypointsInterface = &EntrypointCollection{c}
+	c.ImageRegistriesInterface = &ImageRegistryCollection{c}
+	c.NodesInterface = &NodeCollection{c}
+	c.TasksInterface = &TaskCollection{c}
+
+	c.dockerhub = c.ImageRegistries().New()
+	c.dockerhub.Name = common.IDString("dockerhub")
+
 	// TODO expose as worker num option in main
 	go NewSupervisor(c, 4).Run()
 
@@ -101,15 +110,6 @@ func (c *Core) Initialize() {
 	if err := c.Nodes().populate(); err != nil {
 		panic(err)
 	}
-
-	c.AppsInterface = &AppCollection{c}
-	c.EntrypointsInterface = &EntrypointCollection{c}
-	c.ImageRegistriesInterface = &ImageRegistryCollection{c}
-	c.NodesInterface = &NodeCollection{c}
-	c.TasksInterface = &TaskCollection{c}
-
-	c.dockerhub = c.ImageRegistries().New()
-	c.dockerhub.Name = common.IDString("dockerhub")
 }
 
 // Core implements the Locatable interface, but is only utilized for the child()

--- a/core/core.go
+++ b/core/core.go
@@ -31,11 +31,21 @@ type Core struct {
 	AwsSecretKey           string
 	CapacityServiceEnabled bool
 
-	db          *database
+	db *db
+
 	k8s         guber.Client
 	ec2         *ec2.EC2
 	elb         elbiface.ELBAPI
 	autoscaling autoscalingiface.AutoScalingAPI
+
+	AppsInterface            AppsInterface
+	EntrypointsInterface     EntrypointsInterface
+	ImageRegistriesInterface ImageRegistriesInterface
+	NodesInterface           NodesInterface
+	TasksInterface           TasksInterface
+
+	// NOTE this goes away when Dockerhub is not the only ImageRegistry
+	dockerhub *ImageRegistryResource
 }
 
 var (
@@ -57,7 +67,7 @@ func SetLogLevel(level string) {
 // cli package, I needed to first actually initialize a Core struct and then
 // configure.
 func (c *Core) Initialize() {
-	c.db = newDB(c.EtcdEndpoints)
+	c.db = newdb(c.EtcdEndpoints)
 	c.k8s = guber.NewClient(c.K8sHost, c.K8sUser, c.K8sPass, c.K8sInsecureHTTPS)
 
 	checkForAWSMeta(c)
@@ -91,6 +101,15 @@ func (c *Core) Initialize() {
 	if err := c.Nodes().populate(); err != nil {
 		panic(err)
 	}
+
+	c.AppsInterface = &AppCollection{c}
+	c.EntrypointsInterface = &EntrypointCollection{c}
+	c.ImageRegistriesInterface = &ImageRegistryCollection{c}
+	c.NodesInterface = &NodeCollection{c}
+	c.TasksInterface = &TaskCollection{c}
+
+	c.dockerhub = c.ImageRegistries().New()
+	c.dockerhub.Name = common.IDString("dockerhub")
 }
 
 // Core implements the Locatable interface, but is only utilized for the child()
@@ -124,28 +143,26 @@ func (c *Core) child(key string) (l Locatable) {
 // Top-level resources
 
 func (c *Core) Apps() AppsInterface {
-	return &AppCollection{c}
+	return c.AppsInterface
 }
 
 func (c *Core) Entrypoints() EntrypointsInterface {
-	return &EntrypointCollection{c}
+	return c.EntrypointsInterface
 }
 
 func (c *Core) ImageRegistries() ImageRegistriesInterface {
-	return &ImageRegistryCollection{c}
+	return c.ImageRegistriesInterface
 }
 
 // TODO this goes away when Dockerhub is not the only ImageRegistry
 func (c *Core) ImageRepos() ImageReposInterface {
-	registry := c.ImageRegistries().New()
-	registry.Name = common.IDString("dockerhub")
-	return registry.ImageRepos()
+	return c.dockerhub.ImageRepos()
 }
 
 func (c *Core) Nodes() NodesInterface {
-	return &NodeCollection{c}
+	return c.NodesInterface
 }
 
 func (c *Core) Tasks() TasksInterface {
-	return &TaskCollection{c}
+	return c.TasksInterface
 }

--- a/core/entrypoint_test.go
+++ b/core/entrypoint_test.go
@@ -25,7 +25,9 @@ func TestEntrypointList(t *testing.T) {
 			},
 			nil,
 		)
+
 		core := newMockCore(fakeEtcd)
+		core.EntrypointsInterface = &EntrypointCollection{core}
 		entrypoints := core.Entrypoints()
 
 		Convey("When List() is called", func() {
@@ -99,6 +101,7 @@ func TestEntrypointCreate(t *testing.T) {
 
 		core.AwsSubnetID = "subnet-69420666"
 
+		core.EntrypointsInterface = &EntrypointCollection{core}
 		entrypoints := core.Entrypoints()
 
 		entrypoint := entrypoints.New()
@@ -143,7 +146,9 @@ func TestEntrypointGet(t *testing.T) {
 			}`,
 			nil,
 		)
+
 		core := newMockCore(fakeEtcd)
+		core.EntrypointsInterface = &EntrypointCollection{core}
 		entrypoints := core.Entrypoints()
 
 		Convey("When Get() is called with the Entrypoint name", func() {
@@ -171,6 +176,7 @@ func TestEntrypointUpdate(t *testing.T) {
 		})
 
 		core := newMockCore(fakeEtcd)
+		core.EntrypointsInterface = &EntrypointCollection{core}
 		entrypoints := core.Entrypoints()
 
 		entrypoint := entrypoints.New()
@@ -230,6 +236,7 @@ func TestEntrypointDelete(t *testing.T) {
 
 		core.AwsSubnetID = "subnet-69420666"
 
+		core.EntrypointsInterface = &EntrypointCollection{core}
 		entrypoints := core.Entrypoints()
 
 		entrypoint := entrypoints.New()

--- a/core/etcd.go
+++ b/core/etcd.go
@@ -15,7 +15,7 @@ const (
 	baseDir = "/supergiant"
 )
 
-func newEtcdClient(endpoints []string) *etcdClient {
+func newetcdClient(endpoints []string) *etcdClient {
 	client, err := etcd.New(etcd.Config{Endpoints: endpoints})
 	if err != nil {
 		panic(err)

--- a/core/image_repo_test.go
+++ b/core/image_repo_test.go
@@ -24,6 +24,9 @@ func TestImageRepoList(t *testing.T) {
 			nil,
 		)
 		core := newMockCore(fakeEtcd)
+		core.ImageRegistriesInterface = &ImageRegistryCollection{core}
+		core.dockerhub = core.ImageRegistries().New()
+		core.dockerhub.Name = common.IDString("dockerhub")
 		repos := core.ImageRepos()
 
 		Convey("When List() is called", func() {
@@ -52,6 +55,9 @@ func TestImageRepoCreate(t *testing.T) {
 			return nil
 		})
 		core := newMockCore(fakeEtcd)
+		core.ImageRegistriesInterface = &ImageRegistryCollection{core}
+		core.dockerhub = core.ImageRegistries().New()
+		core.dockerhub.Name = common.IDString("dockerhub")
 
 		repos := core.ImageRepos()
 
@@ -84,6 +90,9 @@ func TestImageRepoGet(t *testing.T) {
 			nil,
 		)
 		core := newMockCore(fakeEtcd)
+		core.ImageRegistriesInterface = &ImageRegistryCollection{core}
+		core.dockerhub = core.ImageRegistries().New()
+		core.dockerhub.Name = common.IDString("dockerhub")
 		repos := core.ImageRepos()
 
 		Convey("When Get() is called with the ImageRepo name", func() {
@@ -112,6 +121,9 @@ func TestImageRepoUpdate(t *testing.T) {
 		})
 
 		core := newMockCore(fakeEtcd)
+		core.ImageRegistriesInterface = &ImageRegistryCollection{core}
+		core.dockerhub = core.ImageRegistries().New()
+		core.dockerhub.Name = common.IDString("dockerhub")
 		repos := core.ImageRepos()
 
 		repo := repos.New()
@@ -139,6 +151,9 @@ func TestImageRepoDelete(t *testing.T) {
 			return nil
 		})
 		core := newMockCore(fakeEtcd)
+		core.ImageRegistriesInterface = &ImageRegistryCollection{core}
+		core.dockerhub = core.ImageRegistries().New()
+		core.dockerhub.Name = common.IDString("dockerhub")
 
 		repos := core.ImageRepos()
 		repo := repos.New()

--- a/core/kube_helpers.go
+++ b/core/kube_helpers.go
@@ -39,8 +39,11 @@ func interpolatedEnvVars(m *common.ContainerBlueprint, instance *InstanceResourc
 	return envVars
 }
 
-func ImageRepoName(m *common.ContainerBlueprint) string {
-	return strings.Split(m.Image, "/")[0]
+func imageRepoName(m *common.ContainerBlueprint) string {
+	if segments := strings.Split(m.Image, "/"); len(segments) > 1 {
+		return segments[0]
+	}
+	return "" // official dockerhub repo
 }
 
 func asKubeContainer(m *common.ContainerBlueprint, instance *InstanceResource) *guber.Container { // NOTE how instance must be passed here

--- a/core/mock/aws_elb.go
+++ b/core/mock/aws_elb.go
@@ -26,10 +26,18 @@ func (f *FakeAwsELB) OnConfigureHealthCheck(clbk func(*elb.ConfigureHealthCheckI
 	return f
 }
 
+func (f *FakeAwsELB) OnDeleteLoadBalancerListeners(clbk func(*elb.DeleteLoadBalancerListenersInput) (*elb.DeleteLoadBalancerListenersOutput, error)) *FakeAwsELB {
+	f.DeleteLoadBalancerListenersFn = func(input *elb.DeleteLoadBalancerListenersInput) (*elb.DeleteLoadBalancerListenersOutput, error) {
+		return clbk(input)
+	}
+	return f
+}
+
 type FakeAwsELB struct {
-	CreateLoadBalancerFn   func(*elb.CreateLoadBalancerInput) (*elb.CreateLoadBalancerOutput, error)
-	DeleteLoadBalancerFn   func(*elb.DeleteLoadBalancerInput) (*elb.DeleteLoadBalancerOutput, error)
-	ConfigureHealthCheckFn func(*elb.ConfigureHealthCheckInput) (*elb.ConfigureHealthCheckOutput, error)
+	CreateLoadBalancerFn          func(*elb.CreateLoadBalancerInput) (*elb.CreateLoadBalancerOutput, error)
+	DeleteLoadBalancerFn          func(*elb.DeleteLoadBalancerInput) (*elb.DeleteLoadBalancerOutput, error)
+	ConfigureHealthCheckFn        func(*elb.ConfigureHealthCheckInput) (*elb.ConfigureHealthCheckOutput, error)
+	DeleteLoadBalancerListenersFn func(*elb.DeleteLoadBalancerListenersInput) (*elb.DeleteLoadBalancerListenersOutput, error)
 }
 
 func (f *FakeAwsELB) AddTagsRequest(*elb.AddTagsInput) (*request.Request, *elb.AddTagsOutput) {
@@ -116,8 +124,8 @@ func (f *FakeAwsELB) DeleteLoadBalancerListenersRequest(*elb.DeleteLoadBalancerL
 	return nil, nil
 }
 
-func (f *FakeAwsELB) DeleteLoadBalancerListeners(*elb.DeleteLoadBalancerListenersInput) (*elb.DeleteLoadBalancerListenersOutput, error) {
-	return nil, nil
+func (f *FakeAwsELB) DeleteLoadBalancerListeners(input *elb.DeleteLoadBalancerListenersInput) (*elb.DeleteLoadBalancerListenersOutput, error) {
+	return f.DeleteLoadBalancerListenersFn(input)
 }
 
 func (f *FakeAwsELB) DeleteLoadBalancerPolicyRequest(*elb.DeleteLoadBalancerPolicyInput) (*request.Request, *elb.DeleteLoadBalancerPolicyOutput) {

--- a/core/mock/guber.go
+++ b/core/mock/guber.go
@@ -29,6 +29,14 @@ func (f *FakeGuber) ReturnOnServiceGet(r *guber.Service, err error) *FakeGuber {
 	})
 }
 
+// func (f *FakeGuber) OnServiceDelete(clbk func(string) error) *FakeGuber {
+// 	return f.mockServices(&FakeGuberServices{
+// 		DeleteFn: func(name string) error {
+// 			return clbk(name)
+// 		},
+// 	})
+// }
+
 func (f *FakeGuber) mockNamespaces(namespaces *FakeGuberNamespaces) *FakeGuber {
 	f.NamespacesFn = func() guber.NamespaceCollection {
 		return namespaces

--- a/core/mock/guber.go
+++ b/core/mock/guber.go
@@ -21,9 +21,24 @@ func (f *FakeGuber) OnNamespaceDelete(clbk func(string) error) *FakeGuber {
 	})
 }
 
+func (f *FakeGuber) ReturnOnServiceGet(r *guber.Service, err error) *FakeGuber {
+	return f.mockServices(&FakeGuberServices{
+		GetFn: func(name string) (*guber.Service, error) {
+			return r, err
+		},
+	})
+}
+
 func (f *FakeGuber) mockNamespaces(namespaces *FakeGuberNamespaces) *FakeGuber {
 	f.NamespacesFn = func() guber.NamespaceCollection {
 		return namespaces
+	}
+	return f
+}
+
+func (f *FakeGuber) mockServices(services *FakeGuberServices) *FakeGuber {
+	f.ServicesFn = func(_ string) guber.ServiceCollection {
+		return services
 	}
 	return f
 }
@@ -106,5 +121,48 @@ func (f *FakeGuberNamespaces) Update(name string, r *guber.Namespace) (*guber.Na
 }
 
 func (f *FakeGuberNamespaces) Delete(name string) error {
+	return f.DeleteFn(name)
+}
+
+type FakeGuberServices struct {
+	MetaFn   func() *guber.CollectionMeta
+	NewFn    func() *guber.Service
+	CreateFn func(e *guber.Service) (*guber.Service, error)
+	QueryFn  func(q *guber.QueryParams) (*guber.ServiceList, error)
+	ListFn   func() (*guber.ServiceList, error)
+	GetFn    func(name string) (*guber.Service, error)
+	UpdateFn func(name string, r *guber.Service) (*guber.Service, error)
+	DeleteFn func(name string) error
+}
+
+func (f *FakeGuberServices) Meta() *guber.CollectionMeta {
+	return f.MetaFn()
+}
+
+func (f *FakeGuberServices) New() *guber.Service {
+	return f.NewFn()
+}
+
+func (f *FakeGuberServices) Create(e *guber.Service) (*guber.Service, error) {
+	return f.CreateFn(e)
+}
+
+func (f *FakeGuberServices) Query(q *guber.QueryParams) (*guber.ServiceList, error) {
+	return f.QueryFn(q)
+}
+
+func (f *FakeGuberServices) List() (*guber.ServiceList, error) {
+	return f.ListFn()
+}
+
+func (f *FakeGuberServices) Get(name string) (*guber.Service, error) {
+	return f.GetFn(name)
+}
+
+func (f *FakeGuberServices) Update(name string, r *guber.Service) (*guber.Service, error) {
+	return f.UpdateFn(name, r)
+}
+
+func (f *FakeGuberServices) Delete(name string) error {
 	return f.DeleteFn(name)
 }

--- a/core/node.go
+++ b/core/node.go
@@ -81,7 +81,7 @@ func (c *NodeCollection) Create(r *NodeResource) error {
 
 	// TODO
 	//
-	// This refreshes the entire database on every create. It should ideally poll
+	// This refreshes the entire db on every create. It should ideally poll
 	// in the background.
 	//
 	if err := c.populate(); err != nil {

--- a/core/release.go
+++ b/core/release.go
@@ -325,7 +325,9 @@ func (r *ReleaseResource) IsStopped() bool {
 
 func (r *ReleaseResource) imageRepoNames() (repoNames []string) { // TODO convert Image into Value object w/ repo, image, version
 	for _, container := range r.Containers {
-		repoNames = append(repoNames, ImageRepoName(container))
+		if repoName := imageRepoName(container); repoName != "" {
+			repoNames = append(repoNames, repoName)
+		}
 	}
 	return uniqStrs(repoNames)
 }

--- a/core/release.go
+++ b/core/release.go
@@ -54,9 +54,11 @@ func (c *ReleaseCollection) initializeResource(in Resource) {
 	r := in.(*ReleaseResource)
 	r.collection = c
 	r.core = c.core
-	r.InstancesInterface = &InstanceCollection{
-		core:    c.core,
-		release: r,
+	if r.InstancesInterface == nil { // don't want to reset for testing purposes
+		r.InstancesInterface = &InstanceCollection{
+			core:    c.core,
+			release: r,
+		}
 	}
 }
 
@@ -299,10 +301,7 @@ func (r *ReleaseResource) Component() *ComponentResource {
 }
 
 func (r *ReleaseResource) Instances() InstancesInterface {
-	return &InstanceCollection{
-		core:    r.core,
-		release: r,
-	}
+	return r.InstancesInterface
 }
 
 func (r *ReleaseResource) IsStarted() bool {

--- a/core/release_test.go
+++ b/core/release_test.go
@@ -1,0 +1,109 @@
+package core
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+
+	etcd "github.com/coreos/etcd/client"
+	"github.com/supergiant/guber"
+	"github.com/supergiant/supergiant/common"
+	"github.com/supergiant/supergiant/core/mock"
+)
+
+var fakeRelease = &common.Release{
+	Meta: &common.Meta{
+		Created: common.TimestampFromString("Tue, 12 Apr 2016 03:54:56 UTC"),
+	},
+	Timestamp:     common.IDString("20160412035456"),
+	InstanceGroup: common.IDString("20160412035456"),
+	InstanceCount: 1,
+	Volumes: []*common.VolumeBlueprint{
+		&common.VolumeBlueprint{
+			Name: common.IDString("data"),
+			Type: "gp2",
+			Size: 20,
+		},
+	},
+	Containers: []*common.ContainerBlueprint{
+		&common.ContainerBlueprint{
+			Image: "mysql",
+			Ports: []*common.Port{
+				&common.Port{
+					Protocol: "TCP",
+					Number:   3306,
+				},
+			},
+			Mounts: []*common.Mount{
+				&common.Mount{
+					Volume: common.IDString("data"),
+					Path:   "/var/lib/mysql",
+				},
+			},
+		},
+	},
+}
+var fakeReleaseJSON = `{
+  "created": "Tue, 12 Apr 2016 03:54:56 UTC",
+  "timestamp": "20160412035456",
+  "instance_group": "20160412035456",
+  "instance_count": 1,
+  "volumes": [
+    {
+      "name": "data",
+      "type": "gp2",
+      "size": 20
+    }
+  ],
+  "containers": [
+    {
+      "image": "mysql",
+      "ports": [
+        {
+          "protocol": "TCP",
+          "number": 3306
+        }
+      ],
+      "mounts": [
+        {
+          "volume": "data",
+          "path": "/var/lib/mysql"
+        }
+      ]
+    }
+  ]
+}`
+
+func TestReleaseList(t *testing.T) {
+	Convey("Given a ReleaseCollection with 1 Release", t, func() {
+		fakeEtcd := new(mock.FakeEtcd).ReturnValuesOnGet([]string{fakeReleaseJSON}, nil)
+		core := newMockCore(fakeEtcd)
+
+		// Kube Services are fetched on decorate()
+		core.k8s = new(mock.FakeGuber).ReturnOnServiceGet(nil, new(guber.Error404)) // service does not exist
+
+		core.AppsInterface = &AppCollection{core}
+		core.EntrypointsInterface = &EntrypointCollection{core}
+		core.ImageRegistriesInterface = &ImageRegistryCollection{core}
+		core.dockerhub = core.ImageRegistries().New()
+		core.dockerhub.ImageReposInterface = new(FakeImageRepoCollection).ReturnOnGet(nil, &etcd.Error{Code: etcd.ErrorCodeKeyNotFound})
+
+		app := core.Apps().New()
+		app.Name = common.IDString("test")
+
+		component := app.Components().New()
+		component.Name = common.IDString("test")
+
+		releases := component.Releases()
+
+		Convey("When List() is called", func() {
+			list, err := releases.List()
+
+			Convey("The return value should be a ReleaseList with 1 Release", func() {
+				So(err, ShouldBeNil)
+				So(list.Items, ShouldHaveLength, 1)
+				So(list.Items[0].Release, ShouldResemble, fakeRelease)
+			})
+		})
+	})
+}

--- a/core/resource.go
+++ b/core/resource.go
@@ -330,7 +330,8 @@ func copyWithoutNoStoreFields(r Resource) Resource {
 // on all fields with the tag sg:"default=something".
 func setDefaultFields(r Resource) {
 	for _, tf := range taggedResourceFieldsOf(r) {
-		if d := tf.Default; d != nil {
+		existingValueIsZero := tf.Field.Interface() == reflect.Zero(tf.Field.Type()).Interface()
+		if d := tf.Default; d != nil && existingValueIsZero {
 			tf.Field.Set(reflect.ValueOf(d))
 		}
 	}

--- a/core/resource.go
+++ b/core/resource.go
@@ -298,7 +298,7 @@ func ZeroPrivateFields(r Resource) {
 // with zero values for any fields with the tag sg:"nostore".
 //
 // NOTE nostore has to be used in conjunction with json:"omitempty" in order to
-// prevent an empty value being stored in the DB. The alternative is to return
+// prevent an empty value being stored in the db. The alternative is to return
 // a copy of the Resource in the form of a map, but that seems kinda difficult.
 func copyWithoutNoStoreFields(r Resource) Resource {
 	origR := reflect.ValueOf(r).Elem()

--- a/core/task.go
+++ b/core/task.go
@@ -79,7 +79,7 @@ func (c *TaskCollection) Start(action *Action) (*TaskResource, error) {
 	task.MaxAttempts = 10
 
 	// NOTE we could set status to RUNNING here, and simply fire off directly
-	// to Supervisor in order to prevent re-loading the Resource from the DB
+	// to Supervisor in order to prevent re-loading the Resource from the db
 	// before performing the action. However, that could introduce complications
 	// if the task fails to start -- at that point it would still be flagged
 	// RUNNING, and never picked up by the Supervisor.
@@ -218,7 +218,7 @@ func (r *TaskResource) IsQueued() bool {
 // Claim updates the Task status to "RUNNING" and returns nil. compareAndSwap is
 // used to prevent a race condition and ensure only one worker performs the task.
 func (r *TaskResource) Claim() error {
-	// NOTE we de-ref the task because the DB will strip the ID (maybe a TODO)
+	// NOTE we de-ref the task because the db will strip the ID (maybe a TODO)
 	prev := *r
 
 	// NOTE we have to do this instead of the above, because nested pointers are

--- a/core/testutils_test.go
+++ b/core/testutils_test.go
@@ -1,0 +1,147 @@
+package core
+
+import (
+	"github.com/supergiant/supergiant/common"
+	"github.com/supergiant/supergiant/core/mock"
+)
+
+func newMockCore(fakeEtcd *mock.FakeEtcd) *Core {
+	return &Core{
+		db: &db{
+			&etcdClient{fakeEtcd},
+		},
+	}
+}
+
+// Components
+//==============================================================================
+
+func (f *FakeComponentCollection) ReturnValuesOnList(components []*common.Component) *FakeComponentCollection {
+	var items []*ComponentResource
+	for _, component := range components {
+		items = append(items, &ComponentResource{
+			core:       f.core,
+			collection: f,
+			Component:  component,
+		})
+	}
+	f.ListFn = func() (*ComponentList, error) {
+		return &ComponentList{Items: items}, nil
+	}
+	return f
+}
+
+func (f *FakeComponentCollection) OnDelete(clbk func(Resource) error) *FakeComponentCollection {
+	f.DeleteFn = func(r Resource) error {
+		return clbk(r)
+	}
+	return f
+}
+
+type FakeComponentCollection struct {
+	core     *Core
+	app      *AppResource
+	ListFn   func() (*ComponentList, error)
+	NewFn    func() *ComponentResource
+	CreateFn func() error
+	GetFn    func() (*ComponentResource, error)
+	UpdateFn func() error
+	PatchFn  func() error
+	DeleteFn func(Resource) error
+	DeployFn func(Resource) error
+}
+
+func (f *FakeComponentCollection) App() *AppResource {
+	return f.app
+}
+
+func (f *FakeComponentCollection) List() (*ComponentList, error) {
+	return f.ListFn()
+}
+
+func (f *FakeComponentCollection) New() *ComponentResource {
+	return f.NewFn()
+}
+
+func (f *FakeComponentCollection) Create(*ComponentResource) error {
+	return f.CreateFn()
+}
+
+func (f *FakeComponentCollection) Get(common.ID) (*ComponentResource, error) {
+	return f.GetFn()
+}
+
+func (f *FakeComponentCollection) Update(common.ID, *ComponentResource) error {
+	return f.UpdateFn()
+}
+
+func (f *FakeComponentCollection) Patch(common.ID, *ComponentResource) error {
+	return f.PatchFn()
+}
+
+func (f *FakeComponentCollection) Delete(r Resource) error {
+	return f.DeleteFn(r)
+}
+
+func (f *FakeComponentCollection) Deploy(r Resource) error {
+	return f.DeployFn(r)
+}
+
+// ImageRepos
+//==============================================================================
+
+func (f *FakeImageRepoCollection) ReturnOnGet(t *common.ImageRepo, err error) *FakeImageRepoCollection {
+	f.GetFn = func() (*ImageRepoResource, error) {
+		if err != nil {
+			return nil, err
+		}
+		return &ImageRepoResource{ImageRepo: t}, nil
+	}
+	return f
+}
+
+func (f *FakeImageRepoCollection) OnDelete(clbk func(*ImageRepoResource) error) *FakeImageRepoCollection {
+	f.DeleteFn = func(r *ImageRepoResource) error {
+		return clbk(r)
+	}
+	return f
+}
+
+type FakeImageRepoCollection struct {
+	core     *Core
+	ListFn   func() (*ImageRepoList, error)
+	NewFn    func() *ImageRepoResource
+	CreateFn func() error
+	GetFn    func() (*ImageRepoResource, error)
+	UpdateFn func() error
+	PatchFn  func() error
+	DeleteFn func(*ImageRepoResource) error
+}
+
+func (f *FakeImageRepoCollection) List() (*ImageRepoList, error) {
+	return f.ListFn()
+}
+
+func (f *FakeImageRepoCollection) New() *ImageRepoResource {
+	return f.NewFn()
+}
+
+func (f *FakeImageRepoCollection) Create(*ImageRepoResource) error {
+	return f.CreateFn()
+}
+
+func (f *FakeImageRepoCollection) Get(common.ID) (*ImageRepoResource, error) {
+	return f.GetFn()
+}
+
+func (f *FakeImageRepoCollection) Update(common.ID, *ImageRepoResource) error {
+	return f.UpdateFn()
+}
+
+func (f *FakeImageRepoCollection) Patch(common.ID, *ImageRepoResource) error {
+	return f.PatchFn()
+}
+
+func (f *FakeImageRepoCollection) Delete(r *ImageRepoResource) error {
+	return f.DeleteFn(r)
+}

--- a/core/testutils_test.go
+++ b/core/testutils_test.go
@@ -145,3 +145,91 @@ func (f *FakeImageRepoCollection) Patch(common.ID, *ImageRepoResource) error {
 func (f *FakeImageRepoCollection) Delete(r *ImageRepoResource) error {
 	return f.DeleteFn(r)
 }
+
+// Releases
+//==============================================================================
+
+func (f *FakeReleaseCollection) ReturnValuesOnList(ts []*common.Release) *FakeReleaseCollection {
+	var items []*ReleaseResource
+	for _, t := range ts {
+		items = append(items, &ReleaseResource{
+			core:       f.core,
+			collection: f,
+			Release:    t,
+		})
+	}
+	f.ListFn = func() (*ReleaseList, error) {
+		return &ReleaseList{Items: items}, nil
+	}
+	return f
+}
+
+func (f *FakeReleaseCollection) ReturnOnGet(t *common.Release, err error) *FakeReleaseCollection {
+	f.GetFn = func() (*ReleaseResource, error) {
+		if err != nil {
+			return nil, err
+		}
+		return &ReleaseResource{
+			core:       f.core,
+			collection: f,
+			Release:    t,
+		}, nil
+	}
+	return f
+}
+
+func (f *FakeReleaseCollection) OnDelete(clbk func(*ReleaseResource) error) *FakeReleaseCollection {
+	f.DeleteFn = func(r *ReleaseResource) error {
+		return clbk(r)
+	}
+	return f
+}
+
+type FakeReleaseCollection struct {
+	core          *Core
+	component     *ComponentResource
+	ListFn        func() (*ReleaseList, error)
+	NewFn         func() *ReleaseResource
+	CreateFn      func() error
+	MergeCreateFn func() error
+	GetFn         func() (*ReleaseResource, error)
+	UpdateFn      func() error
+	PatchFn       func() error
+	DeleteFn      func(*ReleaseResource) error
+}
+
+func (f *FakeReleaseCollection) Component() *ComponentResource {
+	return f.component
+}
+
+func (f *FakeReleaseCollection) List() (*ReleaseList, error) {
+	return f.ListFn()
+}
+
+func (f *FakeReleaseCollection) New() *ReleaseResource {
+	return f.NewFn()
+}
+
+func (f *FakeReleaseCollection) Create(*ReleaseResource) error {
+	return f.CreateFn()
+}
+
+func (f *FakeReleaseCollection) MergeCreate(*ReleaseResource) error {
+	return f.MergeCreateFn()
+}
+
+func (f *FakeReleaseCollection) Get(common.ID) (*ReleaseResource, error) {
+	return f.GetFn()
+}
+
+func (f *FakeReleaseCollection) Update(common.ID, *ReleaseResource) error {
+	return f.UpdateFn()
+}
+
+func (f *FakeReleaseCollection) Patch(common.ID, *ReleaseResource) error {
+	return f.PatchFn()
+}
+
+func (f *FakeReleaseCollection) Delete(r *ReleaseResource) error {
+	return f.DeleteFn(r)
+}

--- a/core/testutils_test.go
+++ b/core/testutils_test.go
@@ -233,3 +233,131 @@ func (f *FakeReleaseCollection) Patch(common.ID, *ReleaseResource) error {
 func (f *FakeReleaseCollection) Delete(r *ReleaseResource) error {
 	return f.DeleteFn(r)
 }
+
+// Entrypoints
+//==============================================================================
+
+func (f *FakeEntrypointCollection) ReturnOnGet(t *common.Entrypoint, err error) *FakeEntrypointCollection {
+	f.GetFn = func() (*EntrypointResource, error) {
+		if err != nil {
+			return nil, err
+		}
+		return &EntrypointResource{
+			core:       f.core,
+			collection: f,
+			Entrypoint: t,
+		}, nil
+	}
+	return f
+}
+
+type FakeEntrypointCollection struct {
+	core     *Core
+	ListFn   func() (*EntrypointList, error)
+	NewFn    func() *EntrypointResource
+	CreateFn func() error
+	GetFn    func() (*EntrypointResource, error)
+	UpdateFn func() error
+	PatchFn  func() error
+	DeleteFn func(*EntrypointResource) error
+}
+
+func (f *FakeEntrypointCollection) List() (*EntrypointList, error) {
+	return f.ListFn()
+}
+
+func (f *FakeEntrypointCollection) New() *EntrypointResource {
+	return f.NewFn()
+}
+
+func (f *FakeEntrypointCollection) Create(*EntrypointResource) error {
+	return f.CreateFn()
+}
+
+func (f *FakeEntrypointCollection) Get(common.ID) (*EntrypointResource, error) {
+	return f.GetFn()
+}
+
+func (f *FakeEntrypointCollection) Update(common.ID, *EntrypointResource) error {
+	return f.UpdateFn()
+}
+
+func (f *FakeEntrypointCollection) Patch(common.ID, *EntrypointResource) error {
+	return f.PatchFn()
+}
+
+func (f *FakeEntrypointCollection) Delete(r *EntrypointResource) error {
+	return f.DeleteFn(r)
+}
+
+// Instances
+//==============================================================================
+
+func (f *FakeInstanceCollection) ReturnValuesOnList(ts []*common.Instance) *FakeInstanceCollection {
+	var items []*InstanceResource
+	for _, t := range ts {
+		items = append(items, &InstanceResource{
+			core:       f.core,
+			collection: f,
+			Instance:   t,
+		})
+	}
+	f.ListFn = func() *InstanceList {
+		return &InstanceList{Items: items}
+	}
+	return f
+}
+
+func (f *FakeInstanceCollection) OnDelete(clbk func(*InstanceResource) error) *FakeInstanceCollection {
+	f.DeleteFn = func(r *InstanceResource) error {
+		return clbk(r)
+	}
+	return f
+}
+
+type FakeInstanceCollection struct {
+	core     *Core
+	release  *ReleaseResource
+	ListFn   func() *InstanceList
+	NewFn    func(common.ID) *InstanceResource
+	GetFn    func(common.ID) (*InstanceResource, error)
+	StartFn  func(Resource) error
+	StopFn   func(Resource) error
+	DeleteFn func(*InstanceResource) error
+}
+
+func (f *FakeInstanceCollection) App() *AppResource {
+	return f.release.Component().App()
+}
+
+func (f *FakeInstanceCollection) Component() *ComponentResource {
+	return f.release.Component()
+}
+
+func (f *FakeInstanceCollection) Release() *ReleaseResource {
+	return f.release
+}
+
+func (f *FakeInstanceCollection) List() *InstanceList {
+	return f.ListFn()
+}
+
+func (f *FakeInstanceCollection) New(id common.ID) *InstanceResource {
+	return f.NewFn(id)
+}
+
+func (f *FakeInstanceCollection) Get(id common.ID) (*InstanceResource, error) {
+	return f.GetFn(id)
+}
+
+func (f *FakeInstanceCollection) Start(ri Resource) error {
+	return f.StartFn(ri)
+}
+
+func (f *FakeInstanceCollection) Stop(ri Resource) error {
+	return f.StopFn(ri)
+}
+
+func (f *FakeInstanceCollection) Delete(r *InstanceResource) error {
+	return f.DeleteFn(r)
+}

--- a/hack/deploy_cms.sh
+++ b/hack/deploy_cms.sh
@@ -18,13 +18,26 @@ curl -XPOST localhost:8080/v0/apps/supergiant-io/components -d '{
 }'
 
 curl -XPOST localhost:8080/v0/apps/supergiant-io/components/mysql/releases -d '{
+  "volumes": [
+    {
+      "name": "data",
+      "type": "gp2",
+      "size": 20
+    }
+  ],
   "containers": [
     {
-      "image": "mysql/mysql-server",
+      "image": "mysql:5.6.30",
       "ports": [
         {
           "protocol": "TCP",
           "number": 3306
+        }
+      ],
+      "mounts": [
+        {
+          "volume": "data",
+          "path": "/var/lib/mysql"
         }
       ],
       "env": [
@@ -63,7 +76,7 @@ curl -XPOST localhost:8080/v0/apps/supergiant-io/components/craft/releases -d '{
         {
           "protocol": "HTTP",
           "number": 80,
-          "external_number": 35555,
+          "external_number": 80,
           "public": true,
           "entrypoint_domain": "example.com"
         }

--- a/hack/deploy_jenkins.sh
+++ b/hack/deploy_jenkins.sh
@@ -26,7 +26,7 @@ curl -XPOST localhost:8080/v0/apps/jenkins/components/jenkins/releases -d '{
         {
           "protocol": "HTTP",
           "number": 8080,
-          "external_number": 33666,
+          "external_number": 80,
           "public": true,
           "entrypoint_domain": "example.com"
         }


### PR DESCRIPTION
The bug fixed was related to default values on resource fields. The default setter function did not account for existing values, and was overwriting user-defined input.