### PR TITLE
Add SecretType to ImageRepo for specifying K8S secret type

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -120,8 +120,9 @@ type ImageRegistry struct {
 
 // TODO this should really be renamed to Org probably
 type ImageRepo struct {
-	Name ID     `json:"name" validate:"nonzero"`
-	Key  string `json:"key" validate:"nonzero" sg:"private"`
+	Name       ID     `json:"name" validate:"nonzero"`
+	Key        string `json:"key" validate:"nonzero" sg:"private"`
+	SecretType string `json:"secret_type" validate:"regexp=^(dockercfg|dockerconfigjson)$" sg:"default=dockercfg"`
 
 	*Meta
 }

--- a/core/image_repo_test.go
+++ b/core/image_repo_test.go
@@ -129,6 +129,7 @@ func TestImageRepoUpdate(t *testing.T) {
 		repo := repos.New()
 		repo.Name = common.IDString("test")
 		repo.Key = "key"
+		repo.SecretType = "dockercfg"
 
 		Convey("When Update() is called", func() {
 			err := repo.Update()

--- a/core/kube_helpers.go
+++ b/core/kube_helpers.go
@@ -175,9 +175,9 @@ func asKubeSecret(m *ImageRepoResource) *guber.Secret {
 		Metadata: &guber.Metadata{
 			Name: common.StringID(m.Name),
 		},
-		Type: "kubernetes.io/dockerconfigjson",
+		Type: "kubernetes.io/" + m.SecretType,
 		Data: map[string]string{
-			".dockerconfigjson": m.Key,
+			"." + m.SecretType: m.Key,
 		},
 	}
 }


### PR DESCRIPTION
This will allow for specifying either `dockercfg` or `dockerconfigjson` on ImageRepos -- Kubernetes takes dockerhub keys in multiple formats for Secrets.