### PR TITLE
CapacityService bugfixes & refactor Ports

### DIFF
--- a/common/values.go
+++ b/common/values.go
@@ -140,7 +140,6 @@ func (c *CoresValue) fromString(str string) error {
 	default:
 		return fmt.Errorf("Could not parse cores value from %s", str)
 	}
-
 	return nil
 }
 
@@ -157,5 +156,5 @@ func (v *CoresValue) ToKubeMillicores() string {
 }
 
 func (v *CoresValue) Cores() float64 {
-	return float64(millicores) / float64(millicores)
+	return float64(v.Millicores) / float64(millicores)
 }

--- a/core/component.go
+++ b/core/component.go
@@ -328,7 +328,7 @@ func (r *ComponentResource) externalAddresses() (addrs []*common.PortAddress, er
 		return nil, err
 	}
 	for _, port := range release.ExternalPorts() {
-		addrs = append(addrs, port.address())
+		addrs = append(addrs, port.externalAddress())
 	}
 	return addrs, nil
 }
@@ -339,7 +339,7 @@ func (r *ComponentResource) internalAddresses() (addrs []*common.PortAddress, er
 		return nil, err
 	}
 	for _, port := range release.InternalPorts() {
-		addrs = append(addrs, port.address())
+		addrs = append(addrs, port.internalAddress())
 	}
 	return addrs, nil
 }

--- a/core/port.go
+++ b/core/port.go
@@ -16,100 +16,89 @@ func protoWithDefault(protocol string) string {
 	return strings.ToLower(protocol)
 }
 
-type port struct {
+type Port struct {
 	*common.Port
-	release *ReleaseResource
-}
-
-func (p *port) name() string {
-	return strconv.Itoa(p.Number)
-}
-
-type InternalPort struct {
-	*port
-}
-
-func newInternalPort(p *common.Port, r *ReleaseResource) *InternalPort {
-	return &InternalPort{
-		port: &port{p, r},
-	}
-}
-
-// a method because this will change on Release
-func (ip *InternalPort) service() *guber.Service {
-	return ip.release.InternalService
-}
-
-func (ip *InternalPort) address() *common.PortAddress {
-	svcMeta := ip.service().Metadata
-	host := fmt.Sprintf("%s.%s.svc.cluster.local", svcMeta.Name, svcMeta.Namespace)
-	return &common.PortAddress{
-		Port:    ip.name(),
-		Address: fmt.Sprintf("%s://%s:%d", protoWithDefault(ip.Protocol), host, ip.Number),
-	}
-}
-
-//==============================================================================
-//==============================================================================
-//==============================================================================
-//==============================================================================
-//==============================================================================
-//==============================================================================
-//==============================================================================
-//==============================================================================
-
-type ExternalPort struct {
-	*port
+	release  *ReleaseResource
+	external bool
+	// entrypoint is nil if it's an internal port
 	entrypoint *EntrypointResource
 }
 
-// NOTE we pass entrypoint here, instead of simply finding from the port
-// definition because it prevents unnecessary multiple lookups on the Entrypoint
-func newExternalPort(p *common.Port, r *ReleaseResource, e *EntrypointResource) *ExternalPort {
-	return &ExternalPort{
-		port:       &port{p, r},
-		entrypoint: e,
-	}
+func (p *Port) name() string {
+	return strconv.Itoa(p.Number)
+}
+
+func newInternalPort(p *common.Port, r *ReleaseResource) *Port {
+	return &Port{p, r, false, nil}
+}
+
+func newExternalPort(p *common.Port, r *ReleaseResource, e *EntrypointResource) *Port {
+	return &Port{p, r, true, e}
 }
 
 // a method because this will change on Release
-func (ep *ExternalPort) service() *guber.Service {
-	return ep.release.ExternalService
+func (p *Port) service() *guber.Service {
+	if p.external {
+		return p.release.ExternalService
+	}
+	return p.release.InternalService
 }
 
-func (ep *ExternalPort) nodePort() int {
-	for _, port := range ep.service().Spec.Ports {
-		if port.Port == ep.Number {
+func (p *Port) internalAddress() *common.PortAddress {
+	svcMeta := p.service().Metadata
+	host := fmt.Sprintf("%s.%s.svc.cluster.local", svcMeta.Name, svcMeta.Namespace)
+	return &common.PortAddress{
+		Port:    p.name(),
+		Address: fmt.Sprintf("%s://%s:%d", protoWithDefault(p.Protocol), host, p.Number),
+	}
+}
+
+func (p *Port) externalAddress() *common.PortAddress {
+	if p.entrypoint == nil {
+		host := ""
+		nodes, err := p.release.core.Nodes().List()
+		if err != nil {
+			Log.Errorf("Error when fetching nodes for external address IP: %s", err)
+		} else if len(nodes.Items) == 0 {
+			Log.Error("Error no nodes present when building external address")
+		} else {
+			host = nodes.Items[0].ExternalIP
+		}
+		return &common.PortAddress{
+			Port:    p.name(),
+			Address: fmt.Sprintf("%s://%s:%d", protoWithDefault(p.Protocol), host, p.nodePort()),
+		}
+	}
+
+	return &common.PortAddress{
+		Port:    p.name(),
+		Address: fmt.Sprintf("%s://%s:%d", protoWithDefault(p.Protocol), p.entrypoint.Address, p.elbPort()),
+	}
+}
+
+// The following methods apply to external ports only
+
+func (p *Port) nodePort() int {
+	for _, port := range p.service().Spec.Ports {
+		if port.Port == p.Number {
 			return port.NodePort
 		}
 	}
 	panic("Could not find NodePort")
 }
 
-func (ep *ExternalPort) elbPort() int {
-	if ep.ExternalNumber != 0 {
-		return ep.ExternalNumber
+func (p *Port) elbPort() int {
+	if p.ExternalNumber != 0 {
+		return p.ExternalNumber
 	}
-	return ep.nodePort()
-}
-
-func (ep *ExternalPort) address() *common.PortAddress {
-	// TODO
-	//
-	// Current it is assumed that all external ports have an entrypoint, which is
-	// not technically true. We should return a random node IP if there is no
-	// entrypoint.
-	return &common.PortAddress{
-		Port:    ep.name(),
-		Address: fmt.Sprintf("%s://%s:%d", protoWithDefault(ep.Protocol), ep.entrypoint.Address, ep.elbPort()),
-	}
+	return p.nodePort()
 }
 
 // TODO like the comment above, this only applies when there is an EntrypointDomain
-func (ep *ExternalPort) addToELB() error {
-	return ep.entrypoint.AddPort(ep.elbPort(), ep.nodePort())
+func (p *Port) addToELB() error {
+	return p.entrypoint.AddPort(p.elbPort(), p.nodePort())
 }
 
-func (ep *ExternalPort) removeFromELB() error {
-	return ep.entrypoint.RemovePort(ep.elbPort())
+func (p *Port) removeFromELB() error {
+	return p.entrypoint.RemovePort(p.elbPort())
 }


### PR DESCRIPTION
- fix CoresValue Cores() method, which was always returning 1
- fix instance type sorting issue in capacityService
- fix nil container.Resources.Limits issue in capacityService (was
  breaking on containers with no resource limits set)
- fix projectedNode.usedVolumes() (should not count non-EBS volumes)
- fix crashing bug in capacityService (was calling
  ProviderCreationTimestamp on wrong Node object)
- consolidate ExternalPort and InternalPort into Port to clean up logic
  in Release for coming service-per-instance feature