### PR TITLE
Show internal addresses for external ports

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -178,7 +178,7 @@ type Addresses struct {
 type CustomDeployScript struct {
 	Image   string   `json:"image" validate:"nonzero,regexp=^[-\\w\\.\\/]+(:[-\\w\\.]+)?$"`
 	Command []string `json:"command"` // TODO need validation here, I think we need to reqire command
-	Timeout uint     `json:"timeout" sg:"default=1800"`
+	Timeout int      `json:"timeout" sg:"default=1800"`
 }
 
 type VolumeBlueprint struct {

--- a/core/component.go
+++ b/core/component.go
@@ -346,12 +346,18 @@ func (r *ComponentResource) internalAddresses() (addrs []*common.PortAddress, er
 	if err != nil {
 		return nil, err
 	}
-	ports, err := release.serviceSet.internalPorts()
+	iPorts, err := release.serviceSet.internalPorts()
 	if err != nil {
 		return nil, err
 	}
+	ePorts, err := release.serviceSet.externalPorts() // external ports also have internal addresses
+	if err != nil {
+		return nil, err
+	}
+	ports := append(iPorts, ePorts...)
 	for _, port := range ports {
 		addrs = append(addrs, port.internalAddress())
 	}
+
 	return addrs, nil
 }

--- a/core/custom_deployment.go
+++ b/core/custom_deployment.go
@@ -94,8 +94,9 @@ func RunCustomDeployment(core *Core, component *ComponentResource) error {
 		return false, nil // pod still exists, keep going
 	})
 
+	Log.Info(log)
+
 	if err != nil {
-		Log.Error(log)
 		return err
 	}
 

--- a/core/entrypoint.go
+++ b/core/entrypoint.go
@@ -227,6 +227,10 @@ func (r *EntrypointResource) RemovePort(elbPort int) error {
 	Log.Infof("Removing port %d from ELB %s", elbPort, *r.awsName())
 
 	_, err := r.core.elb.DeleteLoadBalancerListeners(params)
+	if err != nil && strings.Contains(err.Error(), "LoadBalancerNotFound") { // TODO repeated in delete
+		Log.Warn(err)
+		return nil
+	}
 	return err
 }
 
@@ -326,5 +330,9 @@ func (r *EntrypointResource) deleteELB() error {
 		LoadBalancerName: r.awsName(),
 	}
 	_, err := r.core.elb.DeleteLoadBalancer(params)
+	if err != nil && strings.Contains(err.Error(), "LoadBalancerNotFound") {
+		Log.Warn(err)
+		return nil
+	}
 	return err
 }

--- a/core/port.go
+++ b/core/port.go
@@ -4,18 +4,17 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
-	"strings"
 
 	"github.com/supergiant/guber"
 	"github.com/supergiant/supergiant/common"
 )
 
-func protoWithDefault(protocol string) string {
-	if protocol == "" {
-		return "tcp"
-	}
-	return strings.ToLower(protocol)
-}
+// func protoWithDefault(protocol string) string {
+// 	if protocol == "" {
+// 		return "tcp"
+// 	}
+// 	return strings.ToLower(protocol)
+// }
 
 func findPortsUniqueToSetA(setA []*Port, setB []*Port) (ports []*Port) {
 	for _, pA := range setA {
@@ -57,8 +56,9 @@ func (p *Port) internalAddress() *common.PortAddress {
 	svcMeta := p.service.Metadata
 	host := fmt.Sprintf("%s.%s.svc.cluster.local", svcMeta.Name, svcMeta.Namespace)
 	return &common.PortAddress{
-		Port:    p.name(),
-		Address: fmt.Sprintf("%s://%s:%d", protoWithDefault(p.Protocol), host, p.Number),
+		Port: p.name(),
+		// Address: fmt.Sprintf("%s://%s:%d", protoWithDefault(p.Protocol), host, p.Number),
+		Address: fmt.Sprintf("%s:%d", host, p.Number),
 	}
 }
 
@@ -74,14 +74,16 @@ func (p *Port) externalAddress() *common.PortAddress {
 			host = nodes.Items[0].ExternalIP
 		}
 		return &common.PortAddress{
-			Port:    p.name(),
-			Address: fmt.Sprintf("%s://%s:%d", protoWithDefault(p.Protocol), host, p.nodePort()),
+			Port: p.name(),
+			// Address: fmt.Sprintf("%s://%s:%d", protoWithDefault(p.Protocol), host, p.nodePort()),
+			Address: fmt.Sprintf("%s:%d", host, p.nodePort()),
 		}
 	}
 
 	return &common.PortAddress{
-		Port:    p.name(),
-		Address: fmt.Sprintf("%s://%s:%d", protoWithDefault(p.Protocol), p.entrypoint.Address, p.elbPort()),
+		Port: p.name(),
+		// Address: fmt.Sprintf("%s://%s:%d", protoWithDefault(p.Protocol), p.entrypoint.Address, p.elbPort()),
+		Address: fmt.Sprintf("%s:%d", p.entrypoint.Address, p.elbPort()),
 	}
 }
 

--- a/core/service_set.go
+++ b/core/service_set.go
@@ -230,6 +230,8 @@ func (s *ServiceSet) addExternalPortsToEntrypoint() error {
 	svc, err := s.externalService()
 	if err != nil {
 		return err
+	} else if svc == nil {
+		return nil
 	}
 	ports, err := s.externalPorts()
 	if err != nil {

--- a/hack/deploy_as_component.sh
+++ b/hack/deploy_as_component.sh
@@ -1,43 +1,43 @@
 curl -XPOST localhost:8080/v0/entrypoints -d '{
-  "domain": "test.supergiant.io"
+  "domain": "example.com"
 }' || true
 
 curl -XPOST localhost:8080/v0/apps -d '{
-  "name": "supergiant"
+  "name": "sg-test"
 }'
 
-curl -XPOST localhost:8080/v0/apps/supergiant/components -d '{
+curl -XPOST localhost:8080/v0/apps/sg-test/components -d '{
   "name": "api"
 }'
 
-curl -XPOST localhost:8080/v0/apps/supergiant/components/api/releases -d '{
+curl -XPOST localhost:8080/v0/apps/sg-test/components/api/releases -d '{
   "instance_count": 1,
   "containers": [
     {
       "name": "api",
-      "image": "supergiant/supergiant-api:unstable-custom_deploy_fix",
+      "image": "supergiant/supergiant-api:unstable-internal_addrs_for_external_ports",
       "command": [
         "/supergiant-api",
-        "--etcd-host",
+        "--etcd-hosts",
         "http://localhost:2379",
         "--ar",
-        "us-east-1",
+        "'$AR'",
         "--az",
-        "us-east-1c",
+        "'$AZ'",
         "--sg",
-        "sg-8923f3f1",
+        "'$SG'",
         "--sid",
-        "subnet-21e06f57",
+        "'$SID'",
         "--kh",
-        "52.90.24.78",
-        "--https-mode",
+        "'$KH'",
+        "--k8s-insecure-https",
         "--ku",
-        "admin",
+        "'$KU'",
         "--kp",
-        "86J8mb3b4bDU32cX",
-        "--access-key",
+        "'$KP'",
+        "--aws-access-key",
         "'$AWS_ACCESS_KEY'",
-        "--secret-key",
+        "--aws-secret-key",
         "'$AWS_SECRET_KEY'"
       ],
       "ports": [
@@ -46,7 +46,7 @@ curl -XPOST localhost:8080/v0/apps/supergiant/components/api/releases -d '{
           "number": 8080,
           "external_number": 40000,
           "public": true,
-          "entrypoint_domain": "test.supergiant.io"
+          "entrypoint_domain": "example.com"
         }
       ]
     },
@@ -81,4 +81,4 @@ curl -XPOST localhost:8080/v0/apps/supergiant/components/api/releases -d '{
   ]
 }'
 
-curl -XPOST localhost:8080/v0/apps/supergiant/components/api/deploy
+curl -XPOST localhost:8080/v0/apps/sg-test/components/api/deploy

--- a/hack/deploy_elasticsearch.sh
+++ b/hack/deploy_elasticsearch.sh
@@ -40,11 +40,11 @@ curl -XPOST $HOST/v0/apps/test/components/elasticsearch/releases -d '{
       "image": "qbox/qbox-docker:2.1.1",
       "cpu": {
         "min": 0,
-        "max": 250
+        "max": 0.25
       },
       "ram": {
-        "min": 1024,
-        "max": 1024
+        "min": "1Gi",
+        "max": "1Gi"
       },
       "mounts": [
         {

--- a/hack/deploy_jenkins.sh
+++ b/hack/deploy_jenkins.sh
@@ -14,14 +14,6 @@ curl -XPOST localhost:8080/v0/apps/jenkins/components/jenkins/releases -d '{
   "containers": [
     {
       "image": "jenkins",
-      "cpu": {
-        "min": 0,
-        "max": 0
-      },
-      "ram": {
-        "min": 0,
-        "max": 0
-      },
       "ports": [
         {
           "protocol": "HTTP",

--- a/hack/deploy_mongodb.sh
+++ b/hack/deploy_mongodb.sh
@@ -1,0 +1,65 @@
+curl -XPOST localhost:8080/v0/entrypoints -d '{
+  "domain": "example.com"
+}' || true
+
+curl -XPOST localhost:8080/v0/apps -d '{
+  "name": "test"
+}'
+
+curl -XPOST localhost:8080/v0/apps/test/components -d '{
+  "name": "mongo",
+  "custom_deploy_script": {
+    "image": "supergiant/deploy-mongodb:latest",
+    "command": [
+      "/deploy-mongodb",
+      "--app-name",
+      "test",
+      "--component-name",
+      "mongo"
+    ]
+  }
+}'
+
+curl -XPOST localhost:8080/v0/apps/test/components/mongo/releases -d '{
+  "instance_count": 3,
+  "volumes": [
+    {
+      "name": "mongo-data",
+      "type": "gp2",
+      "size": 10
+    }
+  ],
+  "containers": [
+    {
+      "image": "mongo",
+      "command": [
+        "mongod",
+        "--replSet",
+        "rs0"
+      ],
+      "cpu": {
+        "max": 0.25
+      },
+      "ram": {
+        "max": "1Gi"
+      },
+      "mounts": [
+        {
+          "volume": "mongo-data",
+          "path": "/data/db"
+        }
+      ],
+      "ports": [
+        {
+          "protocol": "TCP",
+          "number": 27017,
+          "public": true,
+          "per_instance": true,
+          "entrypoint_domain": "example.com"
+        }
+      ]
+    }
+  ]
+}'
+
+curl -XPOST localhost:8080/v0/apps/test/components/mongo/deploy


### PR DESCRIPTION
- show internal K8S service addresses for external ports
- change unit Timeout field on CustomDeployScript to int; fixes default
  bug
- always log CustomDeployScript log out
- fix Entrypoint deletion and port removal bug when ELB is missing
- remove protocol from Address strings
- fix missing service bug in ServiceSet
- update examples in hack/