### PR TITLE
Change max len validation on Component name to 17

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -10,7 +10,7 @@ type App struct {
 }
 
 type Component struct {
-	Name ID `json:"name" validate:"nonzero,max=24,regexp=^[a-z]([-a-z0-9]*[a-z0-9])?$"`
+	Name ID `json:"name" validate:"nonzero,max=17,regexp=^[a-z]([-a-z0-9]*[a-z0-9])?$"`
 
 	CustomDeployScript *CustomDeployScript `json:"custom_deploy_script"`
 


### PR DESCRIPTION
This is hopefully just temporary. Need a better strategy for labeling
external resources (such as K8S services and EBS volumes) to avoid name
length limits.