### PR TITLE
fix website link in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Supergiant is API-based stateful container orchestration disguised as a
 developer-friendly application platform. It is based on
 [Kubernetes](https://github.com/kubernetes/kubernetes).
 
-[supergiant.io](supergiant.io)
+[supergiant.io](https://supergiant.io)
 
 ### Concepts
 


### PR DESCRIPTION
currently it points https://github.com/supergiant/supergiant/blob/master/supergiant.io