### PR TITLE
Allow for providing config via JSON file

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,16 +39,7 @@ GRANT ALL PRIVILEGES ON DATABASE supergiant_development to supergiant;
 
 Run
 ```shell
-godep go run main.go \
---psql-host localhost \
---psql-db supergiant_development \
---psql-user supergiant \
---psql-pass password \
---http-basic-user admin \
---http-basic-pass password \
---http-port 8080 \
---log-file tmp/development.log \
---log-level debug
+godep go run main.go --config-file config/config.json
 ```
 
 <!-- ### Tests

--- a/config/config.json
+++ b/config/config.json
@@ -1,0 +1,11 @@
+{
+  "psql_host": "localhost",
+  "psql_db": "supergiant_development",
+  "psql_user": "supergiant",
+  "psql_pass": "password",
+  "http_port": "8080",
+  "http_basic_user": "admin",
+  "http_basic_pass": "password",
+  "log_file": "tmp/development.log",
+  "log_level": "info"
+}

--- a/main.go
+++ b/main.go
@@ -1,25 +1,45 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
 
 	"github.com/codegangsta/cli"
+	"github.com/imdario/mergo"
 	"github.com/supergiant/supergiant/pkg/api"
 	"github.com/supergiant/supergiant/pkg/core"
 	"github.com/supergiant/supergiant/pkg/ui"
 )
 
 func main() {
+	var configFilePath string
+	var configFileSettings core.Settings
+
+	c := new(core.Core)
+
 	app := cli.NewApp()
 	app.Name = "supergiant"
 	app.Usage = "Supergiant"
 
-	c := new(core.Core)
-
 	app.Action = func(ctx *cli.Context) {
+		// Load and parse config file if provided
+		if configFilePath != "" {
+			configFile, err := os.Open(configFilePath)
+			if err != nil {
+				panic(err)
+			}
+			if err := json.NewDecoder(configFile).Decode(&configFileSettings); err != nil {
+				panic(err)
+			}
+		}
+
+		// Merge in command line settings (which overwrite respective config file settings)
+		if err := mergo.Merge(&c.Settings, configFileSettings); err != nil {
+			panic(err)
+		}
 
 		requiredFlags := map[string]string{
 			"psql-host":       c.PsqlHost,
@@ -30,7 +50,6 @@ func main() {
 			"http-basic-user": c.HTTPBasicUser,
 			"http-basic-pass": c.HTTPBasicPass,
 		}
-
 		for flag, val := range requiredFlags {
 			if val == "" {
 				cli.ShowCommandHelp(ctx, fmt.Sprintf("%s required\n", flag))
@@ -109,6 +128,11 @@ func main() {
 			Usage:       "Log level",
 			Destination: &c.LogLevel,
 			// Value:  <--- NOTE just cuz you always forget you can set defaults
+		},
+		cli.StringFlag{
+			Name:        "config-file",
+			Usage:       "JSON config filepath (command line arguments will override the values set here)",
+			Destination: &configFilePath,
 		},
 	}
 

--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -12,16 +12,20 @@ import (
 	_ "github.com/jinzhu/gorm/dialects/postgres"
 )
 
+type Settings struct {
+	PsqlHost      string `json:"psql_host"`
+	PsqlDb        string `json:"psql_db"`
+	PsqlUser      string `json:"psql_user"`
+	PsqlPass      string `json:"psql_pass"`
+	HTTPPort      string `json:"http_port"`
+	HTTPBasicUser string `json:"http_basic_user"`
+	HTTPBasicPass string `json:"http_basic_pass"`
+	LogPath       string `json:"log_file"`
+	LogLevel      string `json:"log_level"`
+}
+
 type Core struct {
-	PsqlHost      string
-	PsqlDb        string
-	PsqlUser      string
-	PsqlPass      string
-	HTTPPort      string
-	HTTPBasicUser string
-	HTTPBasicPass string
-	LogPath       string
-	LogLevel      string
+	Settings
 
 	Log *logrus.Logger
 


### PR DESCRIPTION
Command line flags provided in addition to `--config-file` will
overwrite the respective values set in the config file.

Closes #101 