### PR TITLE
Remove use of AWS AutoScaling Groups in Nodes

### DIFF
--- a/pkg/core/capacity_service.go
+++ b/pkg/core/capacity_service.go
@@ -107,7 +107,7 @@ var instanceTypes = [...]*instanceType{
 
 var (
 	waitBeforeScale         = 2 * time.Minute
-	minAgeToExist           = 10 * time.Minute // this is used to prevent adding more nodes while still-pending pods are scheduling to a new node
+	minAgeToExist           = 20 * time.Minute // this is used to prevent adding more nodes while still-pending pods are scheduling to a new node
 	maxClusteredPodsPerNode = 2                // prevent putting all nodes of a cluster on one host node
 	maxDisksPerNode         = 11
 	trackedEventMessages    = [...]string{
@@ -216,7 +216,6 @@ func (s *KubeScaler) Scale() error {
 					pnode1.Committed = true
 					break
 				}
-
 			}
 		}
 	}
@@ -228,10 +227,6 @@ func (s *KubeScaler) Scale() error {
 	}
 
 	for _, node := range s.kube.Nodes {
-
-		if !node.Ready {
-			continue
-		}
 
 		// TODO ---- need to label them to prevent disk overflow
 

--- a/pkg/core/cloud_accounts.go
+++ b/pkg/core/cloud_accounts.go
@@ -6,7 +6,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/elb"
 	"github.com/aws/aws-sdk-go/service/iam"
@@ -58,8 +57,4 @@ func (c *CloudAccounts) iam(m *models.CloudAccount, region string) *iam.IAM {
 
 func (c *CloudAccounts) elb(m *models.CloudAccount, region string) *elb.ELB {
 	return elb.New(globalAWSSession, c.awsConfig(m, region))
-}
-
-func (c *CloudAccounts) autoscaling(m *models.CloudAccount, region string) *autoscaling.AutoScaling {
-	return autoscaling.New(globalAWSSession, c.awsConfig(m, region))
 }

--- a/pkg/core/port.go
+++ b/pkg/core/port.go
@@ -2,7 +2,6 @@ package core
 
 import (
 	"fmt"
-	"reflect"
 	"strconv"
 
 	"github.com/supergiant/guber"
@@ -13,7 +12,7 @@ func findPortsUniqueToSetA(setA []*Port, setB []*Port) (ports []*Port) {
 	for _, pA := range setA {
 		unique := true
 		for _, pB := range setB {
-			if reflect.DeepEqual(*pA.Port, *pB.Port) {
+			if pA.Port.Number == pB.Port.Number && pA.Port.ExternalNumber == pB.Port.ExternalNumber && pA.Port.Protocol == pB.Port.Protocol {
 				unique = false
 				break
 			}

--- a/pkg/models/kube.go
+++ b/pkg/models/kube.go
@@ -50,14 +50,3 @@ type AWSKubeConfig struct {
 	MasterID                      string `json:"master_id" sg:"readonly"`
 	MasterPublicIP                string `json:"master_public_ip" sg:"readonly"`
 }
-
-func (m *Kube) AutoScalingGroupName(instanceType string) string {
-	return m.Name + "-" + instanceType
-}
-
-func (m *Kube) AutoScalingGroupNames() (names []string) {
-	for _, instanceType := range m.Config.InstanceTypes {
-		names = append(names, m.AutoScalingGroupName(instanceType))
-	}
-	return
-}

--- a/pkg/ui/releases_controller.go
+++ b/pkg/ui/releases_controller.go
@@ -15,7 +15,7 @@ func CreateRelease(sg *client.Client, w http.ResponseWriter, r *http.Request) er
 	}
 	if err := sg.Releases.Create(m); err != nil {
 		return renderTemplate(w, "releases/new.html", map[string]interface{}{
-			"title":      "Releases",
+			"title":      "Components",
 			"formAction": "/ui/releases",
 			"model":      m,
 			"error":      err.Error(),
@@ -37,7 +37,7 @@ func UpdateRelease(sg *client.Client, w http.ResponseWriter, r *http.Request) er
 	m.ID = id
 	if err := sg.Releases.Update(m); err != nil {
 		return renderTemplate(w, "releases/new.html", map[string]interface{}{
-			"title":      "Releases",
+			"title":      "Components",
 			"formAction": fmt.Sprintf("/ui/releases/%d", *m.ID),
 			"model":      m,
 			"error":      err.Error(),


### PR DESCRIPTION
- fix capacity service node termination issue (nodes that weren't marked
  ready weren't terminated, and nodes were never marked ready)
- resolve issue with Kube deletion when master is down (requests to K8S
  API fail during App deletion, so records are sloppily deleted directly
  in Kubes delete method)
- fix bug with port updates (unique port detection required all
  attributes to be unique, but really only numbers/protocol are
  attributes that identify a port)