### PR TITLE
Allow for Kube (re-)Provisioning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ install:
 
 script:
   # Test
-  - govendor test +local
+  # - govendor test +local (NOTE not needed with coverage line below)
 
   # Coverage
   - go list -f "{{ if or (len .TestGoFiles) (len .XTestGoFiles) }}\"go test -covermode=count -coverpkg $(go list ./pkg/... | awk -v ORS=, '{ print $1 }' | sed 's/,$//') -coverprofile={{ .Dir }}/.coverprofile {{ .ImportPath }}\"{{ end }}" ./... | xargs -L 1 sh -c

--- a/pkg/api/kubes_controller.go
+++ b/pkg/api/kubes_controller.go
@@ -60,3 +60,15 @@ func DeleteKube(core *core.Core, user *model.User, r *http.Request) (*Response, 
 	}
 	return itemResponse(core, item, http.StatusAccepted)
 }
+
+func ProvisionKube(core *core.Core, user *model.User, r *http.Request) (*Response, error) {
+	item := new(model.Kube)
+	id, err := parseID(r)
+	if err != nil {
+		return nil, err
+	}
+	if err := core.Kubes.Provision(id, item).Async(); err != nil {
+		return nil, err
+	}
+	return itemResponse(core, item, http.StatusAccepted)
+}

--- a/pkg/api/router.go
+++ b/pkg/api/router.go
@@ -35,6 +35,7 @@ func NewRouter(core *core.Core) *mux.Router {
 	s.HandleFunc("/kubes", restrictedHandler(core, ListKubes)).Methods("GET")
 	s.HandleFunc("/kubes/{id}", restrictedHandler(core, GetKube)).Methods("GET")
 	s.HandleFunc("/kubes/{id}", restrictedHandler(core, UpdateKube)).Methods("PATCH", "PUT")
+	s.HandleFunc("/kubes/{id}/provision", restrictedHandler(core, ProvisionKube)).Methods("POST")
 	s.HandleFunc("/kubes/{id}", restrictedHandler(core, DeleteKube)).Methods("DELETE")
 
 	s.HandleFunc("/kube_resources", restrictedHandler(core, CreateKubeResource)).Methods("POST")

--- a/pkg/client/kubes.go
+++ b/pkg/client/kubes.go
@@ -1,9 +1,16 @@
 package client
 
+import "github.com/supergiant/supergiant/pkg/model"
+
 type KubesInterface interface {
 	CollectionInterface
+	Provision(*int64, *model.Kube) error
 }
 
 type Kubes struct {
 	Collection
+}
+
+func (c *Kubes) Provision(id *int64, m *model.Kube) error {
+	return c.client.request("POST", c.memberPath(id)+"/provision", nil, m, nil)
 }

--- a/pkg/core/action.go
+++ b/pkg/core/action.go
@@ -82,6 +82,9 @@ func (a *Action) Async() error {
 				return // Don't goto Remove from Actions
 			}
 
+			// TODO this should be configurable exponential backoff
+			time.Sleep(time.Second)
+
 			a.Status.Retries++
 		}
 

--- a/pkg/core/entrypoints.go
+++ b/pkg/core/entrypoints.go
@@ -10,26 +10,24 @@ func (c *Entrypoints) Create(m *model.Entrypoint) error {
 	if err := c.Collection.Create(m); err != nil {
 		return err
 	}
+	return c.Core.Entrypoints.Provision(m.ID, m).Async()
+}
 
-	// Load Kube and CloudAccount (Nodes are needed to register with ELB on AWS)
-	m.Kube = new(model.Kube)
-	if err := c.Core.DB.Preload("Nodes").Preload("CloudAccount").First(m.Kube, "name = ?", m.KubeName); err != nil {
-		return err
-	}
-
-	provision := &Action{
+func (c *Entrypoints) Provision(id *int64, m *model.Entrypoint) ActionInterface {
+	return &Action{
 		Status: &model.ActionStatus{
 			Description: "provisioning",
 			MaxRetries:  5,
 		},
-		Core:       c.Core,
-		ResourceID: m.UUID,
-		Model:      m,
+		Core: c.Core,
+		// Nodes are needed to register with ELB on AWS
+		Scope: c.Core.DB.Preload("Kube.CloudAccount").Preload("Kube.Nodes"),
+		Model: m,
+		ID:    id,
 		Fn: func(a *Action) error {
 			return c.Core.CloudAccounts.provider(m.Kube.CloudAccount).CreateEntrypoint(m, a)
 		},
 	}
-	return provision.Async()
 }
 
 func (c *Entrypoints) Delete(id *int64, m *model.Entrypoint) ActionInterface {
@@ -42,14 +40,14 @@ func (c *Entrypoints) Delete(id *int64, m *model.Entrypoint) ActionInterface {
 		Scope: c.Core.DB.Preload("Kube.CloudAccount").Preload("EntrypointListeners"),
 		Model: m,
 		ID:    id,
-		Fn: func(_ *Action) error {
+		Fn: func(a *Action) error {
 			// Delete listener records directly
 			for _, listener := range m.EntrypointListeners {
 				if err := c.Core.DB.Delete(listener); err != nil {
 					return err
 				}
 			}
-			if err := c.Core.CloudAccounts.provider(m.Kube.CloudAccount).DeleteEntrypoint(m); err != nil {
+			if err := c.Core.CloudAccounts.provider(m.Kube.CloudAccount).DeleteEntrypoint(m, a); err != nil {
 				return err
 			}
 			return c.Collection.Delete(id, m)

--- a/pkg/core/procedure.go
+++ b/pkg/core/procedure.go
@@ -1,12 +1,15 @@
 package core
 
-import "github.com/supergiant/supergiant/pkg/model"
+import (
+	"github.com/supergiant/supergiant/pkg/model"
+)
 
 type Procedure struct {
-	Core  *Core
-	Name  string
-	Model model.Model
-	steps []*Step
+	Core   *Core
+	Name   string
+	Model  model.Model
+	Action *Action
+	steps  []*Step
 }
 
 type Step struct {
@@ -19,11 +22,23 @@ func (p *Procedure) AddStep(desc string, fn func() error) {
 }
 
 func (p *Procedure) Run() error {
-	for _, step := range p.steps {
+	for n, step := range p.steps {
+
+		if p.Action.Status.StepsCompleted > n {
+			continue
+		}
+
 		p.Core.Log.Infof("Running step of %s procedure: %s", p.Name, step.desc)
 		if err := step.fn(); err != nil {
 			return err
 		}
+
+		// If there is no error, it means we've moved past whatever error there may
+		// have been from a previous try of this step.
+		p.Action.Status.Error = ""
+		p.Action.Status.StepsCompleted = n + 1
+
+		// We save here so that attributes changed on model during fn() are saved
 		if err := p.Core.DB.Save(p.Model); err != nil {
 			return err
 		}

--- a/pkg/core/provider.go
+++ b/pkg/core/provider.go
@@ -9,20 +9,20 @@ type Provider interface {
 	ValidateAccount(*model.CloudAccount) error
 
 	CreateKube(*model.Kube, *Action) error
-	DeleteKube(*model.Kube) error
+	DeleteKube(*model.Kube, *Action) error
 
 	CreateNode(*model.Node, *Action) error
-	DeleteNode(*model.Node) error
+	DeleteNode(*model.Node, *Action) error
 
 	CreateVolume(*model.Volume, *Action) error
 	KubernetesVolumeDefinition(*model.Volume) *kubernetes.Volume
 	WaitForVolumeAvailable(*model.Volume, *Action) error
 	ResizeVolume(*model.Volume, *Action) error
-	DeleteVolume(*model.Volume) error
+	DeleteVolume(*model.Volume, *Action) error
 
 	CreateEntrypoint(*model.Entrypoint, *Action) error
-	DeleteEntrypoint(*model.Entrypoint) error
+	DeleteEntrypoint(*model.Entrypoint, *Action) error
 
-	CreateEntrypointListener(*model.EntrypointListener) error
-	DeleteEntrypointListener(*model.EntrypointListener) error
+	CreateEntrypointListener(*model.EntrypointListener, *Action) error
+	DeleteEntrypointListener(*model.EntrypointListener, *Action) error
 }

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -36,11 +36,12 @@ type BaseModel struct {
 // ActionStatus holds all the information pertaining to any running or failed
 // Async Actions, and is rendered on the model on display (not persisted).
 type ActionStatus struct {
-	Description string `json:"description"`
-	MaxRetries  int    `json:"max_retries"`
-	Retries     int    `json:"retries"`
-	Error       string `json:"error,omitempty"`
-	Cancelled   bool   `json:"cancelled,omitempty"`
+	Description    string `json:"description"`
+	MaxRetries     int    `json:"max_retries"`
+	Retries        int    `json:"retries"`
+	Error          string `json:"error,omitempty"`
+	Cancelled      bool   `json:"cancelled,omitempty"`
+	StepsCompleted int    `json:"steps_completed,omitempty"`
 }
 
 // GetID returns the model ID.

--- a/pkg/provider/aws/provider.go
+++ b/pkg/provider/aws/provider.go
@@ -65,15 +65,15 @@ func (p *Provider) CreateKube(m *model.Kube, action *core.Action) error {
 	return p.createKube(m, action)
 }
 
-func (p *Provider) DeleteKube(m *model.Kube) error {
-	return p.deleteKube(m)
+func (p *Provider) DeleteKube(m *model.Kube, action *core.Action) error {
+	return p.deleteKube(m, action)
 }
 
 func (p *Provider) CreateNode(m *model.Node, action *core.Action) error {
 	return p.createNode(m)
 }
 
-func (p *Provider) DeleteNode(m *model.Node) error {
+func (p *Provider) DeleteNode(m *model.Node, action *core.Action) error {
 	return p.deleteServer(m)
 }
 
@@ -99,7 +99,7 @@ func (p *Provider) WaitForVolumeAvailable(m *model.Volume, action *core.Action) 
 	return p.waitForAvailable(m)
 }
 
-func (p *Provider) DeleteVolume(m *model.Volume) error {
+func (p *Provider) DeleteVolume(m *model.Volume, action *core.Action) error {
 	return p.deleteVolume(m)
 }
 
@@ -107,11 +107,11 @@ func (p *Provider) CreateEntrypoint(m *model.Entrypoint, action *core.Action) er
 	return p.createELB(m)
 }
 
-func (p *Provider) DeleteEntrypoint(m *model.Entrypoint) error {
+func (p *Provider) DeleteEntrypoint(m *model.Entrypoint, action *core.Action) error {
 	return p.deleteELB(m)
 }
 
-func (p *Provider) CreateEntrypointListener(m *model.EntrypointListener) error {
+func (p *Provider) CreateEntrypointListener(m *model.EntrypointListener, action *core.Action) error {
 	input := &elb.CreateLoadBalancerListenersInput{
 		LoadBalancerName: aws.String(m.Entrypoint.ProviderID),
 		Listeners: []*elb.Listener{
@@ -127,7 +127,7 @@ func (p *Provider) CreateEntrypointListener(m *model.EntrypointListener) error {
 	return err
 }
 
-func (p *Provider) DeleteEntrypointListener(m *model.EntrypointListener) error {
+func (p *Provider) DeleteEntrypointListener(m *model.EntrypointListener, action *core.Action) error {
 	input := &elb.DeleteLoadBalancerListenersInput{
 		LoadBalancerName: aws.String(m.Entrypoint.ProviderID),
 		LoadBalancerPorts: []*int64{
@@ -170,9 +170,10 @@ func (p *Provider) createKube(m *model.Kube, action *core.Action) error {
 	iamS := p.IAM(m)
 	ec2S := p.EC2(m)
 	procedure := &core.Procedure{
-		Core:  p.Core,
-		Name:  "Create Kube",
-		Model: m,
+		Core:   p.Core,
+		Name:   "Create Kube",
+		Model:  m,
+		Action: action,
 	}
 
 	procedure.AddStep("preparing IAM Role kubernetes-master", func() error {
@@ -780,12 +781,13 @@ func (p *Provider) createKube(m *model.Kube, action *core.Action) error {
 	return procedure.Run()
 }
 
-func (p *Provider) deleteKube(m *model.Kube) error {
+func (p *Provider) deleteKube(m *model.Kube, action *core.Action) error {
 	ec2S := p.EC2(m)
 	procedure := &core.Procedure{
-		Core:  p.Core,
-		Name:  "Delete Kube",
-		Model: m,
+		Core:   p.Core,
+		Name:   "Delete Kube",
+		Model:  m,
+		Action: action,
 	}
 
 	procedure.AddStep("deleting master", func() error {

--- a/pkg/provider/aws/provider_test.go
+++ b/pkg/provider/aws/provider_test.go
@@ -720,7 +720,8 @@ func TestAWSProviderDeleteKube(t *testing.T) {
 				},
 			}
 
-			err := provider.DeleteKube(item.kube)
+			action := &core.Action{Status: new(model.ActionStatus)}
+			err := provider.DeleteKube(item.kube, action)
 
 			So(err, ShouldResemble, item.err)
 		}
@@ -856,7 +857,8 @@ func TestAWSProviderDeleteNode(t *testing.T) {
 				},
 			}
 
-			err := provider.DeleteNode(item.node)
+			action := &core.Action{Status: new(model.ActionStatus)}
+			err := provider.DeleteNode(item.node, action)
 
 			So(err, ShouldResemble, item.err)
 		}
@@ -1156,7 +1158,8 @@ func TestAWSProviderDeleteVolume(t *testing.T) {
 				},
 			}
 
-			err := provider.DeleteVolume(item.volume)
+			action := &core.Action{Status: new(model.ActionStatus)}
+			err := provider.DeleteVolume(item.volume, action)
 
 			So(err, ShouldResemble, item.err)
 		}
@@ -1298,7 +1301,8 @@ func TestAWSProviderDeleteEntrypoint(t *testing.T) {
 				},
 			}
 
-			err := provider.DeleteEntrypoint(item.entrypoint)
+			action := &core.Action{Status: new(model.ActionStatus)}
+			err := provider.DeleteEntrypoint(item.entrypoint, action)
 
 			So(err, ShouldResemble, item.err)
 		}
@@ -1349,7 +1353,8 @@ func TestAWSProviderCreateEntrypointListener(t *testing.T) {
 				},
 			}
 
-			err := provider.CreateEntrypointListener(item.entrypointListener)
+			action := &core.Action{Status: new(model.ActionStatus)}
+			err := provider.CreateEntrypointListener(item.entrypointListener, action)
 
 			So(err, ShouldResemble, item.err)
 		}
@@ -1415,7 +1420,8 @@ func TestAWSProviderDeleteEntrypointListener(t *testing.T) {
 				},
 			}
 
-			err := provider.DeleteEntrypointListener(item.entrypointListener)
+			action := &core.Action{Status: new(model.ActionStatus)}
+			err := provider.DeleteEntrypointListener(item.entrypointListener, action)
 
 			So(err, ShouldResemble, item.err)
 		}

--- a/pkg/provider/digitalocean/provider.go
+++ b/pkg/provider/digitalocean/provider.go
@@ -32,9 +32,10 @@ func (p *Provider) ValidateAccount(m *model.CloudAccount) error {
 // CreateKube creates a new DO kubernetes cluster.
 func (p *Provider) CreateKube(m *model.Kube, action *core.Action) error {
 	procedure := &core.Procedure{
-		Core:  p.Core,
-		Name:  "Create Kube",
-		Model: m,
+		Core:   p.Core,
+		Name:   "Create Kube",
+		Model:  m,
+		Action: action,
 	}
 
 	client := p.Client(m)
@@ -140,14 +141,15 @@ func (p *Provider) CreateKube(m *model.Kube, action *core.Action) error {
 }
 
 // DeleteKube deletes a DO kubernetes cluster.
-func (p *Provider) DeleteKube(m *model.Kube) error {
+func (p *Provider) DeleteKube(m *model.Kube, action *core.Action) error {
 	// New Client
 	client := p.Client(m)
 	// Step procedure
 	procedure := &core.Procedure{
-		Core:  p.Core,
-		Name:  "Delete Kube",
-		Model: m,
+		Core:   p.Core,
+		Name:   "Delete Kube",
+		Model:  m,
+		Action: action,
 	}
 
 	procedure.AddStep("deleting master", func() error {
@@ -228,7 +230,7 @@ func (p *Provider) CreateNode(m *model.Node, action *core.Action) error {
 }
 
 // DeleteNode deletes a minsion on a DO kubernetes cluster.
-func (p *Provider) DeleteNode(m *model.Node) error {
+func (p *Provider) DeleteNode(m *model.Node, action *core.Action) error {
 	client := p.Client(m.Kube)
 
 	intID, err := strconv.Atoi(m.ProviderID)
@@ -286,7 +288,7 @@ func (p *Provider) WaitForVolumeAvailable(m *model.Volume, action *core.Action) 
 }
 
 // DeleteVolume deletes a DO volume.
-func (p *Provider) DeleteVolume(m *model.Volume) error {
+func (p *Provider) DeleteVolume(m *model.Volume, action *core.Action) error {
 	if m.ProviderID == "" {
 		p.Core.Log.Warnf("Deleting DigitalOcean Volume '%s' with empty ProviderID", m.Name)
 		return nil
@@ -301,15 +303,15 @@ func (p *Provider) CreateEntrypoint(m *model.Entrypoint, action *core.Action) er
 }
 
 // DeleteEntrypoint deletes load balancer from DO.
-func (p *Provider) DeleteEntrypoint(m *model.Entrypoint) error {
+func (p *Provider) DeleteEntrypoint(m *model.Entrypoint, action *core.Action) error {
 	return nil
 }
 
-func (p *Provider) CreateEntrypointListener(m *model.EntrypointListener) error {
+func (p *Provider) CreateEntrypointListener(m *model.EntrypointListener, action *core.Action) error {
 	return nil
 }
 
-func (p *Provider) DeleteEntrypointListener(m *model.EntrypointListener) error {
+func (p *Provider) DeleteEntrypointListener(m *model.EntrypointListener, action *core.Action) error {
 	return nil
 }
 

--- a/pkg/provider/digitalocean/provider_test.go
+++ b/pkg/provider/digitalocean/provider_test.go
@@ -185,7 +185,8 @@ func TestDigitalOceanProviderDeleteKube(t *testing.T) {
 				},
 			}
 
-			err := provider.DeleteKube(item.kube)
+			action := &core.Action{Status: new(model.ActionStatus)}
+			err := provider.DeleteKube(item.kube, action)
 
 			So(err, ShouldEqual, item.err)
 		}
@@ -307,7 +308,8 @@ func TestDigitalOceanProviderDeleteNode(t *testing.T) {
 				},
 			}
 
-			err := provider.DeleteNode(item.node)
+			action := &core.Action{Status: new(model.ActionStatus)}
+			err := provider.DeleteNode(item.node, action)
 
 			So(err, ShouldEqual, item.err)
 		}
@@ -526,7 +528,8 @@ func TestDigitalOceanProviderDeleteVolume(t *testing.T) {
 				},
 			}
 
-			err := provider.DeleteVolume(item.volume)
+			action := &core.Action{Status: new(model.ActionStatus)}
+			err := provider.DeleteVolume(item.volume, action)
 
 			So(err, ShouldEqual, item.err)
 		}

--- a/pkg/ui/kubes_controller.go
+++ b/pkg/ui/kubes_controller.go
@@ -106,6 +106,10 @@ func ListKubes(sg *client.Client, w http.ResponseWriter, r *http.Request) error 
 			"digitalocean": "DigitalOcean",
 		},
 		"batchActionPaths": map[string]map[string]string{
+			"Reprovision": map[string]string{
+				"method":       "POST",
+				"relativePath": "/provision",
+			},
 			"Delete": map[string]string{
 				"method":       "DELETE",
 				"relativePath": "",

--- a/test/fake_client/fake_kubes.go
+++ b/test/fake_client/fake_kubes.go
@@ -1,5 +1,15 @@
 package fake_client
 
+import "github.com/supergiant/supergiant/pkg/model"
+
 type Kubes struct {
 	Collection
+	ProvisionFn func(*int64, *model.Kube) error
+}
+
+func (c *Kubes) Provision(id *int64, m *model.Kube) error {
+	if c.ProvisionFn == nil {
+		return nil
+	}
+	return c.ProvisionFn(id, m)
 }

--- a/test/fake_core/fake_entrypoint_listeners.go
+++ b/test/fake_core/fake_entrypoint_listeners.go
@@ -7,6 +7,7 @@ import (
 
 type EntrypointListeners struct {
 	CreateFn          func(*model.EntrypointListener) error
+	ProvisionFn       func(*int64, *model.EntrypointListener) core.ActionInterface
 	GetFn             func(*int64, model.Model) error
 	GetWithIncludesFn func(*int64, model.Model, []string) error
 	UpdateFn          func(*int64, model.Model, model.Model) error
@@ -18,6 +19,13 @@ func (c *EntrypointListeners) Create(m *model.EntrypointListener) error {
 		return nil
 	}
 	return c.CreateFn(m)
+}
+
+func (c *EntrypointListeners) Provision(id *int64, m *model.EntrypointListener) core.ActionInterface {
+	if c.ProvisionFn == nil {
+		return nil
+	}
+	return c.ProvisionFn(id, m)
 }
 
 func (c *EntrypointListeners) Get(id *int64, m model.Model) error {

--- a/test/fake_core/fake_nodes.go
+++ b/test/fake_core/fake_nodes.go
@@ -7,6 +7,7 @@ import (
 
 type Nodes struct {
 	CreateFn                       func(*model.Node) error
+	ProvisionFn                    func(*int64, *model.Node) core.ActionInterface
 	GetFn                          func(*int64, model.Model) error
 	GetWithIncludesFn              func(*int64, model.Model, []string) error
 	UpdateFn                       func(*int64, model.Model, model.Model) error
@@ -19,6 +20,13 @@ func (c *Nodes) Create(m *model.Node) error {
 		return nil
 	}
 	return c.CreateFn(m)
+}
+
+func (c *Nodes) Provision(id *int64, m *model.Node) core.ActionInterface {
+	if c.ProvisionFn == nil {
+		return nil
+	}
+	return c.ProvisionFn(id, m)
 }
 
 func (c *Nodes) Get(id *int64, m model.Model) error {

--- a/test/fake_core/fake_provider.go
+++ b/test/fake_core/fake_provider.go
@@ -9,18 +9,18 @@ import (
 type Provider struct {
 	ValidateAccountFn            func(*model.CloudAccount) error
 	CreateKubeFn                 func(*model.Kube, *core.Action) error
-	DeleteKubeFn                 func(*model.Kube) error
+	DeleteKubeFn                 func(*model.Kube, *core.Action) error
 	CreateNodeFn                 func(*model.Node, *core.Action) error
-	DeleteNodeFn                 func(*model.Node) error
+	DeleteNodeFn                 func(*model.Node, *core.Action) error
 	CreateVolumeFn               func(*model.Volume, *core.Action) error
 	KubernetesVolumeDefinitionFn func(*model.Volume) *kubernetes.Volume
 	WaitForVolumeAvailableFn     func(*model.Volume, *core.Action) error
 	ResizeVolumeFn               func(*model.Volume, *core.Action) error
-	DeleteVolumeFn               func(*model.Volume) error
+	DeleteVolumeFn               func(*model.Volume, *core.Action) error
 	CreateEntrypointFn           func(*model.Entrypoint, *core.Action) error
-	DeleteEntrypointFn           func(*model.Entrypoint) error
-	CreateEntrypointListenerFn   func(*model.EntrypointListener) error
-	DeleteEntrypointListenerFn   func(*model.EntrypointListener) error
+	DeleteEntrypointFn           func(*model.Entrypoint, *core.Action) error
+	CreateEntrypointListenerFn   func(*model.EntrypointListener, *core.Action) error
+	DeleteEntrypointListenerFn   func(*model.EntrypointListener, *core.Action) error
 }
 
 func (p *Provider) ValidateAccount(m *model.CloudAccount) error {
@@ -37,11 +37,11 @@ func (p *Provider) CreateKube(m *model.Kube, a *core.Action) error {
 	return p.CreateKubeFn(m, a)
 }
 
-func (p *Provider) DeleteKube(m *model.Kube) error {
+func (p *Provider) DeleteKube(m *model.Kube, a *core.Action) error {
 	if p.DeleteKubeFn == nil {
 		return nil
 	}
-	return p.DeleteKubeFn(m)
+	return p.DeleteKubeFn(m, a)
 }
 
 func (p *Provider) CreateNode(m *model.Node, a *core.Action) error {
@@ -51,11 +51,11 @@ func (p *Provider) CreateNode(m *model.Node, a *core.Action) error {
 	return p.CreateNodeFn(m, a)
 }
 
-func (p *Provider) DeleteNode(m *model.Node) error {
+func (p *Provider) DeleteNode(m *model.Node, a *core.Action) error {
 	if p.DeleteNodeFn == nil {
 		return nil
 	}
-	return p.DeleteNodeFn(m)
+	return p.DeleteNodeFn(m, a)
 }
 
 func (p *Provider) CreateVolume(m *model.Volume, a *core.Action) error {
@@ -86,11 +86,11 @@ func (p *Provider) ResizeVolume(m *model.Volume, a *core.Action) error {
 	return p.ResizeVolumeFn(m, a)
 }
 
-func (p *Provider) DeleteVolume(m *model.Volume) error {
+func (p *Provider) DeleteVolume(m *model.Volume, a *core.Action) error {
 	if p.DeleteVolumeFn == nil {
 		return nil
 	}
-	return p.DeleteVolumeFn(m)
+	return p.DeleteVolumeFn(m, a)
 }
 
 func (p *Provider) CreateEntrypoint(m *model.Entrypoint, a *core.Action) error {
@@ -100,23 +100,23 @@ func (p *Provider) CreateEntrypoint(m *model.Entrypoint, a *core.Action) error {
 	return p.CreateEntrypointFn(m, a)
 }
 
-func (p *Provider) DeleteEntrypoint(m *model.Entrypoint) error {
+func (p *Provider) DeleteEntrypoint(m *model.Entrypoint, a *core.Action) error {
 	if p.DeleteEntrypointFn == nil {
 		return nil
 	}
-	return p.DeleteEntrypointFn(m)
+	return p.DeleteEntrypointFn(m, a)
 }
 
-func (p *Provider) CreateEntrypointListener(m *model.EntrypointListener) error {
+func (p *Provider) CreateEntrypointListener(m *model.EntrypointListener, a *core.Action) error {
 	if p.CreateEntrypointListenerFn == nil {
 		return nil
 	}
-	return p.CreateEntrypointListenerFn(m)
+	return p.CreateEntrypointListenerFn(m, a)
 }
 
-func (p *Provider) DeleteEntrypointListener(m *model.EntrypointListener) error {
+func (p *Provider) DeleteEntrypointListener(m *model.EntrypointListener, a *core.Action) error {
 	if p.DeleteEntrypointListenerFn == nil {
 		return nil
 	}
-	return p.DeleteEntrypointListenerFn(m)
+	return p.DeleteEntrypointListenerFn(m, a)
 }

--- a/test/fake_core/fake_volumes.go
+++ b/test/fake_core/fake_volumes.go
@@ -7,6 +7,7 @@ import (
 
 type Volumes struct {
 	CreateFn           func(*model.Volume) error
+	ProvisionFn        func(*int64, *model.Volume) core.ActionInterface
 	GetFn              func(*int64, model.Model) error
 	GetWithIncludesFn  func(*int64, model.Model, []string) error
 	UpdateFn           func(*int64, *model.Volume, *model.Volume) error
@@ -20,6 +21,13 @@ func (c *Volumes) Create(m *model.Volume) error {
 		return nil
 	}
 	return c.CreateFn(m)
+}
+
+func (c *Volumes) Provision(id *int64, m *model.Volume) core.ActionInterface {
+	if c.ProvisionFn == nil {
+		return nil
+	}
+	return c.ProvisionFn(id, m)
 }
 
 func (c *Volumes) Get(id *int64, m model.Model) error {

--- a/test/integration/api/entrypoint_listeners_test.go
+++ b/test/integration/api/entrypoint_listeners_test.go
@@ -217,7 +217,7 @@ func TestEntrypointListenersCreate(t *testing.T) {
 
 			srv.Core.AWSProvider = func(_ map[string]string) core.Provider {
 				return &fake_core.Provider{
-					CreateEntrypointListenerFn: func(m *model.EntrypointListener) error {
+					CreateEntrypointListenerFn: func(m *model.EntrypointListener, _ *core.Action) error {
 						return item.mockCreateEntrypointListenerError
 					},
 				}
@@ -672,7 +672,7 @@ func TestEntrypointListenersDelete(t *testing.T) {
 
 			srv.Core.AWSProvider = func(_ map[string]string) core.Provider {
 				return &fake_core.Provider{
-					DeleteEntrypointListenerFn: func(_ *model.EntrypointListener) error {
+					DeleteEntrypointListenerFn: func(_ *model.EntrypointListener, _ *core.Action) error {
 						return item.mockDeleteEntrypointListenerError
 					},
 				}

--- a/test/integration/api/entrypoints_test.go
+++ b/test/integration/api/entrypoints_test.go
@@ -515,7 +515,7 @@ func TestEntrypointsDelete(t *testing.T) {
 
 			srv.Core.AWSProvider = func(_ map[string]string) core.Provider {
 				return &fake_core.Provider{
-					DeleteEntrypointFn: func(_ *model.Entrypoint) error {
+					DeleteEntrypointFn: func(_ *model.Entrypoint, _ *core.Action) error {
 						return item.mockProviderDeleteEntrypointError
 					},
 				}

--- a/test/integration/api/nodes_test.go
+++ b/test/integration/api/nodes_test.go
@@ -505,7 +505,7 @@ func TestNodesDelete(t *testing.T) {
 
 			srv.Core.AWSProvider = func(_ map[string]string) core.Provider {
 				return &fake_core.Provider{
-					DeleteNodeFn: func(_ *model.Node) error {
+					DeleteNodeFn: func(_ *model.Node, _ *core.Action) error {
 						return item.mockProviderDeleteNodeError
 					},
 				}

--- a/test/integration/api/volumes_test.go
+++ b/test/integration/api/volumes_test.go
@@ -584,7 +584,7 @@ func TestVolumesDelete(t *testing.T) {
 
 			srv.Core.AWSProvider = func(_ map[string]string) core.Provider {
 				return &fake_core.Provider{
-					DeleteVolumeFn: func(_ *model.Volume) error {
+					DeleteVolumeFn: func(_ *model.Volume, _ *core.Action) error {
 						return item.mockProviderDeleteVolumeError
 					},
 				}


### PR DESCRIPTION
- separate "provision" Actions, which were embedded in Create methods in
  relevant resources, into their own methods
- add StepsCompleted field to ActionStatus
- don't repeat step once completed in Procedure
- clear previous error from ActionStatus on subsequent step success