### PR TITLE
Remove deprecated api-version flag. Fixes #181.

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -345,7 +345,6 @@ func (sgcli *CLI) commandKubectl(c *cli.Context) error {
 	}
 
 	args := []string{
-		"--api-version=v1",
 		"--insecure-skip-tls-verify=true",
 		"--server=https://" + kube.MasterPublicIP,
 		"--cluster=" + kube.Name,


### PR DESCRIPTION
This is a quick fix to get rid of the api-version deprecation warning.