### PR TITLE
Deploy to VPC

### DIFF
--- a/pkg/model/kube.go
+++ b/pkg/model/kube.go
@@ -74,7 +74,8 @@ type AWSKubeConfig struct {
 	LastSelectedAZ                string   `json:"last_selected_az" sg:"readonly"` // if using multiAZ this is the last az the node build used.
 	ETCDDiscoveryURL              string   `json:"etcd_discovery_url" sg:"readonly"`
 	PrivateKey                    string   `json:"private_key,omitempty" sg:"readonly"`
-	VPCID                         string   `json:"vpc_id" sg:"readonly"`
+	VPCID                         string   `json:"vpc_id"`
+	VPCMANAGED                    bool     `json:"vpc_managed"`
 	InternetGatewayID             string   `json:"internet_gateway_id" sg:"readonly"`
 	RouteTableID                  string   `json:"route_table_id" sg:"readonly"`
 	RouteTableSubnetAssociationID []string `json:"route_table_subnet_association_id" sg:"readonly"`

--- a/pkg/provider/aws/create_kube.go
+++ b/pkg/provider/aws/create_kube.go
@@ -275,6 +275,12 @@ func (p *Provider) CreateKube(m *model.Kube, action *core.Action) error {
 
 	procedure.AddStep("creating VPC", func() error {
 		if m.AWSConfig.VPCID != "" {
+			m.AWSConfig.VPCMANAGED = true
+			err := p.Core.DB.Save(m)
+			if err != nil {
+				return err
+			}
+			procedure.Core.Log.Info("This VPC is not managed. Using VPC ID supplied by user.")
 			return nil
 		}
 		input := &ec2.CreateVpcInput{

--- a/pkg/provider/aws/delete_kube.go
+++ b/pkg/provider/aws/delete_kube.go
@@ -241,7 +241,10 @@ func (p *Provider) DeleteKube(m *model.Kube, action *core.Action) error {
 	})
 
 	procedure.AddStep("deleting VPC", func() error {
-
+		if m.AWSConfig.VPCMANAGED {
+			procedure.Core.Log.Info("This VPC is not managed. It is NOT being deleted.")
+			return nil
+		}
 		// Delete the VPC
 		_, err := ec2S.DeleteVpc(&ec2.DeleteVpcInput{
 			VpcId: aws.String(m.AWSConfig.VPCID),


### PR DESCRIPTION
- This change allows a user to deploy a kubernetes cluster to an existing VPC.
This is done by specifying the "vpc_id" option with the VPC ID as a string.
Supergiant will then mark the VPC as not managed and deploy into the VPC. When
The cluster is deleted, it will skip destruction of the VPC. NOTE: User must be
aware to configure IP ranges correctly in the kube config during deploy. Missmatched
IP ranges will result in a build error. Fixes #163