### PR TITLE
Update to CoreOS update scheme.

### DIFF
--- a/config/providers/aws/bootstrap.yaml
+++ b/config/providers/aws/bootstrap.yaml
@@ -33,6 +33,8 @@ write_files:
       ## Run the build
       /usr/bin/coreos-cloudinit --from-file /tmp/master.yaml
 coreos:
+  update:
+    reboot-strategy: off
   units:
     - name: bypass-user-data-limit.service
       command: start

--- a/config/providers/aws/master.yaml
+++ b/config/providers/aws/master.yaml
@@ -618,6 +618,8 @@ write_files:
             initialDelaySeconds: 15
             timeoutSeconds: 1
 coreos:
+  update:
+    reboot-strategy: off
   etcd2:
     advertise-client-urls: http://$private_ipv4:2379
     initial-advertise-peer-urls: http://$private_ipv4:2380

--- a/config/providers/aws/minion.yaml
+++ b/config/providers/aws/minion.yaml
@@ -90,6 +90,8 @@ write_files:
         name: service-account-context
       current-context: service-account-context
 coreos:
+  update:
+    reboot-strategy: off
   flannel:
     iface: $COREOS_PRIVATE_IPV4
     etcd_endpoints: http://{{ .Kube.AWSConfig.MasterPrivateIP }}:2379

--- a/config/providers/digitalocean/master.yaml
+++ b/config/providers/digitalocean/master.yaml
@@ -583,6 +583,8 @@ write_files:
             initialDelaySeconds: 15
             timeoutSeconds: 1
 coreos:
+  update:
+    reboot-strategy: off
   etcd2:
     advertise-client-urls: http://$public_ipv4:2379
     listen-client-urls: http://0.0.0.0:2379

--- a/config/providers/digitalocean/minion.yaml
+++ b/config/providers/digitalocean/minion.yaml
@@ -267,6 +267,8 @@ write_files:
         name: service-account-context
       current-context: service-account-context
 coreos:
+  update:
+    reboot-strategy: off
   flannel:
     iface: $public_ipv4
     etcd_endpoints: http://{{ .Kube.MasterPublicIP }}:2379

--- a/config/providers/gce/master.yaml
+++ b/config/providers/gce/master.yaml
@@ -620,6 +620,8 @@ write_files:
             initialDelaySeconds: 15
             timeoutSeconds: 1
 coreos:
+  update:
+    reboot-strategy: off
   etcd2:
     advertise-client-urls: http://$private_ipv4:2379
     initial-advertise-peer-urls: http://$private_ipv4:2380

--- a/config/providers/gce/minion.yaml
+++ b/config/providers/gce/minion.yaml
@@ -97,6 +97,8 @@ write_files:
         name: service-account-context
       current-context: service-account-context
 coreos:
+  update:
+    reboot-strategy: off
   flannel:
     iface: $COREOS_PRIVATE_IPV4
     etcd_endpoints: http://{{ .Kube.GCEConfig.MasterPrivateIP }}:2379

--- a/config/providers/openstack/master.yaml
+++ b/config/providers/openstack/master.yaml
@@ -599,6 +599,8 @@ write_files:
             initialDelaySeconds: 15
             timeoutSeconds: 1
 coreos:
+  update:
+    reboot-strategy: off
   etcd2:
     advertise-client-urls: http://$private_ipv4:2379
     listen-client-urls: http://0.0.0.0:2379

--- a/config/providers/openstack/minion.yaml
+++ b/config/providers/openstack/minion.yaml
@@ -102,6 +102,8 @@ write_files:
         name: service-account-context
       current-context: service-account-context
 coreos:
+  update:
+    reboot-strategy: off
   flannel:
     iface: $COREOS_PRIVATE_IPV4
     etcd_endpoints: http://{{ .Kube.OpenStackConfig.MasterPrivateIP }}:2379


### PR DESCRIPTION
Fixes #194
This change sets nodes to not auto-reboot after update.
This can be modified after build by the user.