### PR TITLE
Bug Fixes for AWS Multi-Master & Multi-AZ

### DIFF
--- a/config/providers/aws/bootstrap.yaml
+++ b/config/providers/aws/bootstrap.yaml
@@ -14,7 +14,7 @@ write_files:
       TOKEN=$(curl -s http://169.254.169.254/latest/meta-data/iam/security-credentials/${PROFILE} | jq -r .Token)
       ## Bucket Info
       FILE="build/master.yaml"
-      BUCKET="kubernetes-{{ .Name }}"
+      BUCKET="{{ .AWSConfig.BucketName }}"
       DATE="$(date +'%a, %d %b %Y %H:%M:%S %z')"
       RESOURCE="/${BUCKET}/${FILE}"
       SIG_STRING="GET\n\n\n${DATE}\nx-amz-security-token:${TOKEN}\n/${RESOURCE}"

--- a/config/providers/aws/master.yaml
+++ b/config/providers/aws/master.yaml
@@ -33,7 +33,7 @@ write_files:
       tar -C /tmp -xvf /tmp/helm-v2.1.3-linux-amd64.tar.gz
       cp /tmp/linux-amd64/helm /opt/bin/helm
       chmod +x /opt/bin/helm
-      /opt/bin/helm init
+
 
       openssl genrsa -out /etc/kubernetes/ssl/ca-key.pem 2048
       openssl req -x509 -new -nodes -key /etc/kubernetes/ssl/ca-key.pem -days 10000 -out /etc/kubernetes/ssl/ca.pem -subj "/CN=kube-ca"
@@ -62,7 +62,8 @@ write_files:
       /opt/bin/kubectl create -f /etc/kubernetes/addons/kube-dns.yaml
       /opt/bin/kubectl create -f /etc/kubernetes/addons/cluster-monitoring
       /opt/bin/kubectl create -f /etc/kubernetes/addons/cluster-utils
-      /opt/bin/helm init
+      sudo -i /opt/bin/helm init
+      sudo -i /opt/bin/helm search
   - path: "/etc/kubernetes/ssl/openssl.cnf.template"
     permissions: "0755"
     content: |

--- a/pkg/core/nodes.go
+++ b/pkg/core/nodes.go
@@ -45,7 +45,7 @@ func (c *Nodes) Provision(id *int64, m *model.Node) ActionInterface {
 			MaxRetries: 0,
 		},
 		Core:  c.Core,
-		Scope: c.Core.DB.Preload("Kube.CloudAccount"),
+		Scope: c.Core.DB.Preload("Kube.CloudAccount").Preload("Kube.Nodes"),
 		Model: m,
 		ID:    id,
 		Fn: func(a *Action) error {

--- a/pkg/model/kube.go
+++ b/pkg/model/kube.go
@@ -68,6 +68,7 @@ type AWSKubeConfig struct {
 	KubeMasterCount     int                 `json:"kube_master_count"`
 	MultiAZ             bool                `json:"multi_az"`
 	SSHPubKey           string              `json:"ssh_pub_key"`
+	BucketName          string              `json:"bucket_name,omitempty" sg:"readonly"`
 	KubernetesVersion   string              `json:"kubernetes_version" validate:"nonzero" sg:"default=1.5.1"`
 
 	MasterPrivateIP               string   `json:"master_private_ip" sg:"readonly"`

--- a/pkg/provider/aws/create_kube_test.go
+++ b/pkg/provider/aws/create_kube_test.go
@@ -41,6 +41,7 @@ func TestAWSProviderCreateKube(t *testing.T) {
 			mockCreateSecurityGroupError           error
 			mockAuthorizeSecurityGroupIngressError error
 			mockRunInstancesError                  error
+			mockDescribeAvailabilityZonesError     error
 			mockDescribeInstancesError             error
 			mockGetInstanceProfileError            error
 			mockCreateInstanceProfileError         error
@@ -386,6 +387,17 @@ func TestAWSProviderCreateKube(t *testing.T) {
 								Instances: []*ec2.Instance{
 									{
 										InstanceId: awssdk.String("instance-id"),
+									},
+								},
+							}
+							return output, item.mockRunInstancesError
+						},
+						DescribeAvailabilityZonesFn: func(input *ec2.DescribeAvailabilityZonesInput) (*ec2.DescribeAvailabilityZonesOutput, error) {
+							output := &ec2.DescribeAvailabilityZonesOutput{
+								AvailabilityZones: []*ec2.AvailabilityZone{
+									{
+										ZoneName: awssdk.String("aws-zone"),
+										State:    awssdk.String("available"),
 									},
 								},
 							}

--- a/pkg/provider/aws/create_node.go
+++ b/pkg/provider/aws/create_node.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"bytes"
 	"encoding/base64"
+	"fmt"
 	"math/rand"
 	"text/template"
 	"time"
@@ -50,7 +51,8 @@ func (p *Provider) CreateNode(m *model.Node, action *core.Action) error {
 	if len(subnets) == 1 {
 		selectedSubnet = subnets[0]
 	} else {
-		selectedSubnet = subnets[random(0, len(subnets)-1)]
+		fmt.Println("Number of nodes:", len(m.Kube.Nodes))
+		selectedSubnet = subnets[(len(m.Kube.Nodes)-1)%len(m.Kube.AWSConfig.PublicSubnetIPRange)]
 	}
 
 	resp, err := ec2S.RunInstances(&ec2.RunInstancesInput{

--- a/pkg/provider/aws/provider.go
+++ b/pkg/provider/aws/provider.go
@@ -296,3 +296,13 @@ func etcdToken(num string) (string, error) {
 	}
 	return string(body), nil
 }
+
+func bucketExist(s3S s3iface.S3API, name string) bool {
+	_, err := s3S.ListObjects(&s3.ListObjectsInput{
+		Bucket: aws.String(name),
+	})
+	if err != nil {
+		return false
+	}
+	return true
+}

--- a/pkg/ui/kubes_controller.go
+++ b/pkg/ui/kubes_controller.go
@@ -82,13 +82,6 @@ func NewKube(sg *client.Client, w http.ResponseWriter, r *http.Request) error {
 			"aws_config": map[string]interface{}{
 				"region":       "us-east-1",
 				"vpc_ip_range": "172.20.0.0/16",
-				"public_subnet_ip_range": []map[string]string{
-					map[string]string{
-						"zone":      "us-east-1b",
-						"ip_range":  "172.20.0.0/24",
-						"subnet_id": "",
-					},
-				},
 			},
 		}
 	}


### PR DESCRIPTION
This change fixes #193
 - ETCD clustering.
 - Improve Multi-AZ az selection for multi master and nodes.
 - simplify the AZ assignment process.

EXAMPLES:

To launch a multi-master kube:

specify `"kube_master_count": 5,` to tell supergiant how many masters need to be used.

To launch multi-master + multi-az:

specify `"kube_master_count": 5,` to tell supergiant how many masters need to be used.
specify `"multi_az": true,` to tell supergiant to install supergiant across all available az. (Will work with single master as well.)

For specific control over az deployment.

specify `"kube_master_count": 5,` to tell supergiant how many masters need to be used.

specify an array of az for which supergiant is to install.
Use the `public_subnet_ip_range` option. (if this option is not set, supergiant will default to either single az, or full multi az.)

```
            "public_subnet_ip_range": [
            {
                "ip_range": "172.20.1.0/24",
                "subnet_id": "",
                "zone": "us-east-1b"
            },
            {
                "ip_range": "172.20.2.0/24",
                "subnet_id": "",
                "zone": "us-east-1c"
            }
        ]
```