### PR TITLE
Make AWS S3 bucket name lowercase.

### DIFF
--- a/pkg/provider/aws/create_kube.go
+++ b/pkg/provider/aws/create_kube.go
@@ -222,7 +222,7 @@ func (p *Provider) CreateKube(m *model.Kube, action *core.Action) error {
 	})
 
 	procedure.AddStep("creating S3 bucket", func() error {
-		m.AWSConfig.BucketName = "kubernetes-" + m.Name + "-" + util.RandomString(10)
+		m.AWSConfig.BucketName = strings.ToLower("kubernetes-" + m.Name + "-" + util.RandomString(10))
 		_, err := s3S.CreateBucket(&s3.CreateBucketInput{
 			Bucket: aws.String(m.AWSConfig.BucketName),
 		})


### PR DESCRIPTION
S3 requires bucket names to be lowercase in some regions. (Ireland for example)