### PR TITLE
Master and Node volume size option.

### DIFF
--- a/pkg/model/kube.go
+++ b/pkg/model/kube.go
@@ -69,6 +69,8 @@ type AWSKubeConfig struct {
 	MultiAZ             bool                `json:"multi_az"`
 	SSHPubKey           string              `json:"ssh_pub_key"`
 	BucketName          string              `json:"bucket_name,omitempty" sg:"readonly"`
+	NodeVolumeSize      int                 `json:"node_volume_size"`
+	MasterVolumeSize    int                 `json:"master_volume_size"`
 	KubernetesVersion   string              `json:"kubernetes_version" validate:"nonzero" sg:"default=1.5.1"`
 
 	MasterPrivateIP               string   `json:"master_private_ip" sg:"readonly"`

--- a/pkg/model/kube.go
+++ b/pkg/model/kube.go
@@ -69,8 +69,8 @@ type AWSKubeConfig struct {
 	MultiAZ             bool                `json:"multi_az"`
 	SSHPubKey           string              `json:"ssh_pub_key"`
 	BucketName          string              `json:"bucket_name,omitempty" sg:"readonly"`
-	NodeVolumeSize      int                 `json:"node_volume_size"`
-	MasterVolumeSize    int                 `json:"master_volume_size"`
+	NodeVolumeSize      int                 `json:"node_volume_size" sg:"default=100"`
+	MasterVolumeSize    int                 `json:"master_volume_size" sg:"default=100"`
 	KubernetesVersion   string              `json:"kubernetes_version" validate:"nonzero" sg:"default=1.5.1"`
 
 	MasterPrivateIP               string   `json:"master_private_ip" sg:"readonly"`

--- a/pkg/provider/aws/create_kube.go
+++ b/pkg/provider/aws/create_kube.go
@@ -711,14 +711,6 @@ func (p *Provider) CreateKube(m *model.Kube, action *core.Action) error {
 				selectedSubnet = subnets[(i-1)%len(m.AWSConfig.PublicSubnetIPRange)]
 			}
 
-			//Volume size
-			var volumeSize int
-			if m.AWSConfig.MasterVolumeSize == 0 {
-				volumeSize = 100
-			} else {
-				volumeSize = m.AWSConfig.MasterVolumeSize
-			}
-
 			time.Sleep(5 * time.Second)
 			procedure.Core.Log.Info("Building master #" + strconv.Itoa(i) + ", in subnet " + selectedSubnet + "...")
 			resp, err := ec2S.RunInstances(&ec2.RunInstancesInput{
@@ -748,7 +740,7 @@ func (p *Provider) CreateKube(m *model.Kube, action *core.Action) error {
 						Ebs: &ec2.EbsBlockDevice{
 							DeleteOnTermination: aws.Bool(true),
 							VolumeType:          aws.String("gp2"),
-							VolumeSize:          aws.Int64(int64(volumeSize)),
+							VolumeSize:          aws.Int64(int64(m.AWSConfig.MasterVolumeSize)),
 						},
 					},
 				},

--- a/pkg/provider/aws/create_kube.go
+++ b/pkg/provider/aws/create_kube.go
@@ -711,6 +711,14 @@ func (p *Provider) CreateKube(m *model.Kube, action *core.Action) error {
 				selectedSubnet = subnets[(i-1)%len(m.AWSConfig.PublicSubnetIPRange)]
 			}
 
+			//Volume size
+			var volumeSize int
+			if m.AWSConfig.MasterVolumeSize == 0 {
+				volumeSize = 100
+			} else {
+				volumeSize = m.AWSConfig.MasterVolumeSize
+			}
+
 			time.Sleep(5 * time.Second)
 			procedure.Core.Log.Info("Building master #" + strconv.Itoa(i) + ", in subnet " + selectedSubnet + "...")
 			resp, err := ec2S.RunInstances(&ec2.RunInstancesInput{
@@ -736,11 +744,11 @@ func (p *Provider) CreateKube(m *model.Kube, action *core.Action) error {
 				},
 				BlockDeviceMappings: []*ec2.BlockDeviceMapping{
 					{
-						DeviceName: aws.String("/dev/xvdb"),
+						DeviceName: aws.String("/dev/xvda"),
 						Ebs: &ec2.EbsBlockDevice{
 							DeleteOnTermination: aws.Bool(true),
 							VolumeType:          aws.String("gp2"),
-							VolumeSize:          aws.Int64(20),
+							VolumeSize:          aws.Int64(int64(volumeSize)),
 						},
 					},
 				},

--- a/pkg/provider/aws/create_node.go
+++ b/pkg/provider/aws/create_node.go
@@ -55,14 +55,6 @@ func (p *Provider) CreateNode(m *model.Node, action *core.Action) error {
 		selectedSubnet = subnets[(len(m.Kube.Nodes)-1)%len(m.Kube.AWSConfig.PublicSubnetIPRange)]
 	}
 
-	// volumes
-	var volume int
-	if m.Kube.AWSConfig.NodeVolumeSize == 0 {
-		volume = 100
-	} else {
-		volume = m.Kube.AWSConfig.NodeVolumeSize
-	}
-
 	resp, err := ec2S.RunInstances(&ec2.RunInstancesInput{
 		MinCount:     aws.Int64(1),
 		MaxCount:     aws.Int64(1),
@@ -82,7 +74,7 @@ func (p *Provider) CreateNode(m *model.Node, action *core.Action) error {
 				Ebs: &ec2.EbsBlockDevice{
 					DeleteOnTermination: aws.Bool(true),
 					VolumeType:          aws.String("gp2"),
-					VolumeSize:          aws.Int64(int64(volume)),
+					VolumeSize:          aws.Int64(int64(m.Kube.AWSConfig.NodeVolumeSize)),
 				},
 			},
 		},


### PR DESCRIPTION
This change adds a simple volume size option for
master and minion nodes in the config.

```
    NodeVolumeSize      int                 `json:"node_volume_size"`
    MasterVolumeSize    int                 `json:"master_volume_size"`
```

if left blank, the size will default to 100GB