### PR TITLE
Update to Docker service drop-in

### DIFF
--- a/config/providers/aws/master.yaml
+++ b/config/providers/aws/master.yaml
@@ -633,56 +633,23 @@ coreos:
   units:
     - name: etcd2.service
       command: start
-    - name: flanneld.service
-      content: |
-        [Unit]
-        Description=Network fabric for containers
-        Documentation=https://github.com/coreos/flannel
-        Requires=early-docker.service
-        After=etcd.service etcd2.service early-docker.service
-        Before=early-docker.target
-        [Service]
-        Type=notify
-        Restart=always
-        RestartSec=5
-        Environment="TMPDIR=/var/tmp/"
-        Environment="DOCKER_HOST=unix:///var/run/early-docker.sock"
-        Environment="FLANNEL_VER=0.5.5"
-        Environment="ETCD_SSL_DIR=/etc/ssl/etcd"
-        Environment="FLANNEL_ENV_FILE=/run/flannel/options.env"
-        LimitNOFILE=40000
-        LimitNPROC=1048576
-        ExecStartPre=/sbin/modprobe ip_tables
-        ExecStartPre=/usr/bin/mkdir -p /run/flannel
-        ExecStartPre=/usr/bin/mkdir -p ${ETCD_SSL_DIR}
-        ExecStartPre=-/usr/bin/touch ${FLANNEL_ENV_FILE}
-        ExecStart=/usr/libexec/sdnotify-proxy /run/flannel/sd.sock \
-          /usr/bin/docker run --net=host --privileged=true --rm \
-          --volume=/run/flannel:/run/flannel \
-          --env=NOTIFY_SOCKET=/run/flannel/sd.sock \
-          --env-file=${FLANNEL_ENV_FILE} \
-          --volume=/usr/share/ca-certificates:/etc/ssl/certs:ro \
-          --volume=${ETCD_SSL_DIR}:/etc/ssl/etcd:ro \
-          quay.io/coreos/flannel:${FLANNEL_VER} /opt/bin/flanneld --ip-masq=true
-        # Update docker options
-        ExecStartPost=/usr/bin/docker run --net=host --rm -v /run:/run \
-          quay.io/coreos/flannel:${FLANNEL_VER} \
-          /opt/bin/mk-docker-opts.sh -d /run/flannel_docker_opts.env -i
+    - name: "flanneld.service"
+      command: start
       drop-ins:
-        - name: "50-ExecStartPre-flannel-network.conf"
+        - name: 50-network-config.conf
           content: |
+            [Unit]
+            Requires=etcd2.service
             [Service]
-            ExecStartPre=/usr/bin/curl -X PUT -d "value={\"Network\":\"10.2.0.0/16\",\"Backend\":{\"Type\":\"vxlan\"}}" http://127.0.0.1:2379/v2/keys/coreos.com/network/config
-    - name: docker.service
+            ExecStartPre=/usr/bin/etcdctl set /coreos.com/network/config '{"Network":"10.2.0.0/16", "Backend": {"Type": "vxlan"}}'
+    - name: "docker.service"
+      command: start
       drop-ins:
-        - name: "40-flannel.conf"
+        - name: 40-flannel.conf
           content: |
             [Unit]
             Requires=flanneld.service
             After=flanneld.service
-            [Service]
-            Restart=always
-            Restart=on-failure
     - name: kubelet.service
       command: start
       content: |

--- a/config/providers/aws/minion.yaml
+++ b/config/providers/aws/minion.yaml
@@ -97,51 +97,23 @@ coreos:
     etcd_endpoints: http://{{ .Kube.AWSConfig.MasterPrivateIP }}:2379
 
   units:
-    - name: flanneld.service
-      content: |
-        [Unit]
-        Description=Network fabric for containers
-        Documentation=https://github.com/coreos/flannel
-        Requires=early-docker.service
-        After=etcd.service etcd2.service early-docker.service
-        Before=early-docker.target
-        [Service]
-        Type=notify
-        Restart=always
-        RestartSec=5
-        Environment="TMPDIR=/var/tmp/"
-        Environment="DOCKER_HOST=unix:///var/run/early-docker.sock"
-        Environment="FLANNEL_VER=0.5.5"
-        Environment="ETCD_SSL_DIR=/etc/ssl/etcd"
-        Environment="FLANNEL_ENV_FILE=/run/flannel/options.env"
-        LimitNOFILE=40000
-        LimitNPROC=1048576
-        ExecStartPre=/sbin/modprobe ip_tables
-        ExecStartPre=/usr/bin/mkdir -p /run/flannel
-        ExecStartPre=/usr/bin/mkdir -p ${ETCD_SSL_DIR}
-        ExecStartPre=-/usr/bin/touch ${FLANNEL_ENV_FILE}
-        ExecStart=/usr/libexec/sdnotify-proxy /run/flannel/sd.sock \
-          /usr/bin/docker run --net=host --privileged=true --rm \
-          --volume=/run/flannel:/run/flannel \
-          --env=NOTIFY_SOCKET=/run/flannel/sd.sock \
-          --env-file=${FLANNEL_ENV_FILE} \
-          --volume=/usr/share/ca-certificates:/etc/ssl/certs:ro \
-          --volume=${ETCD_SSL_DIR}:/etc/ssl/etcd:ro \
-          quay.io/coreos/flannel:${FLANNEL_VER} /opt/bin/flanneld --ip-masq=true
-        # Update docker options
-        ExecStartPost=/usr/bin/docker run --net=host --rm -v /run:/run \
-          quay.io/coreos/flannel:${FLANNEL_VER} \
-          /opt/bin/mk-docker-opts.sh -d /run/flannel_docker_opts.env -i
-    - name: docker.service
+    - name: "flanneld.service"
+      command: start
       drop-ins:
-        - name: "40-flannel.conf"
+        - name: 50-network-config.conf
+          content: |
+            [Unit]
+            Requires=etcd2.service
+            [Service]
+            ExecStartPre=/usr/bin/etcdctl set /coreos.com/network/config '{"Network":"10.2.0.0/16", "Backend": {"Type": "vxlan"}}'
+    - name: "docker.service"
+      command: start
+      drop-ins:
+        - name: 40-flannel.conf
           content: |
             [Unit]
             Requires=flanneld.service
             After=flanneld.service
-            [Service]
-            Restart=always
-            Restart=on-failure
     - name: kubelet.service
       command: start
       content: |

--- a/config/providers/digitalocean/master.yaml
+++ b/config/providers/digitalocean/master.yaml
@@ -594,56 +594,23 @@ coreos:
   units:
     - name: etcd2.service
       command: start
-    - name: flanneld.service
-      content: |
-        [Unit]
-        Description=Network fabric for containers
-        Documentation=https://github.com/coreos/flannel
-        Requires=early-docker.service
-        After=etcd.service etcd2.service early-docker.service
-        Before=early-docker.target
-        [Service]
-        Type=notify
-        Restart=always
-        RestartSec=5
-        Environment="TMPDIR=/var/tmp/"
-        Environment="DOCKER_HOST=unix:///var/run/early-docker.sock"
-        Environment="FLANNEL_VER=0.5.5"
-        Environment="ETCD_SSL_DIR=/etc/ssl/etcd"
-        Environment="FLANNEL_ENV_FILE=/run/flannel/options.env"
-        LimitNOFILE=40000
-        LimitNPROC=1048576
-        ExecStartPre=/sbin/modprobe ip_tables
-        ExecStartPre=/usr/bin/mkdir -p /run/flannel
-        ExecStartPre=/usr/bin/mkdir -p ${ETCD_SSL_DIR}
-        ExecStartPre=-/usr/bin/touch ${FLANNEL_ENV_FILE}
-        ExecStart=/usr/libexec/sdnotify-proxy /run/flannel/sd.sock \
-          /usr/bin/docker run --net=host --privileged=true --rm \
-          --volume=/run/flannel:/run/flannel \
-          --env=NOTIFY_SOCKET=/run/flannel/sd.sock \
-          --env-file=${FLANNEL_ENV_FILE} \
-          --volume=/usr/share/ca-certificates:/etc/ssl/certs:ro \
-          --volume=${ETCD_SSL_DIR}:/etc/ssl/etcd:ro \
-          quay.io/coreos/flannel:${FLANNEL_VER} /opt/bin/flanneld --ip-masq=true
-        # Update docker options
-        ExecStartPost=/usr/bin/docker run --net=host --rm -v /run:/run \
-          quay.io/coreos/flannel:${FLANNEL_VER} \
-          /opt/bin/mk-docker-opts.sh -d /run/flannel_docker_opts.env -i
+    - name: "flanneld.service"
+      command: start
       drop-ins:
-        - name: "50-ExecStartPre-flannel-network.conf"
+        - name: 50-network-config.conf
           content: |
+            [Unit]
+            Requires=etcd2.service
             [Service]
-            ExecStartPre=/usr/bin/curl -X PUT -d "value={\"Network\":\"10.2.0.0/16\",\"Backend\":{\"Type\":\"vxlan\"}}" http://127.0.0.1:2379/v2/keys/coreos.com/network/config
-    - name: docker.service
+            ExecStartPre=/usr/bin/etcdctl set /coreos.com/network/config '{"Network":"10.2.0.0/16", "Backend": {"Type": "vxlan"}}'
+    - name: "docker.service"
+      command: start
       drop-ins:
-        - name: "40-flannel.conf"
+        - name: 40-flannel.conf
           content: |
             [Unit]
             Requires=flanneld.service
             After=flanneld.service
-            [Service]
-            Restart=always
-            Restart=on-failure
     - name: kubelet.service
       command: start
       content: |

--- a/config/providers/digitalocean/minion.yaml
+++ b/config/providers/digitalocean/minion.yaml
@@ -274,51 +274,23 @@ coreos:
     etcd_endpoints: http://{{ .Kube.MasterPublicIP }}:2379
 
   units:
-    - name: flanneld.service
-      content: |
-        [Unit]
-        Description=Network fabric for containers
-        Documentation=https://github.com/coreos/flannel
-        Requires=early-docker.service
-        After=etcd.service etcd2.service early-docker.service
-        Before=early-docker.target
-        [Service]
-        Type=notify
-        Restart=always
-        RestartSec=5
-        Environment="TMPDIR=/var/tmp/"
-        Environment="DOCKER_HOST=unix:///var/run/early-docker.sock"
-        Environment="FLANNEL_VER=0.5.5"
-        Environment="ETCD_SSL_DIR=/etc/ssl/etcd"
-        Environment="FLANNEL_ENV_FILE=/run/flannel/options.env"
-        LimitNOFILE=40000
-        LimitNPROC=1048576
-        ExecStartPre=/sbin/modprobe ip_tables
-        ExecStartPre=/usr/bin/mkdir -p /run/flannel
-        ExecStartPre=/usr/bin/mkdir -p ${ETCD_SSL_DIR}
-        ExecStartPre=-/usr/bin/touch ${FLANNEL_ENV_FILE}
-        ExecStart=/usr/libexec/sdnotify-proxy /run/flannel/sd.sock \
-          /usr/bin/docker run --net=host --privileged=true --rm \
-          --volume=/run/flannel:/run/flannel \
-          --env=NOTIFY_SOCKET=/run/flannel/sd.sock \
-          --env-file=${FLANNEL_ENV_FILE} \
-          --volume=/usr/share/ca-certificates:/etc/ssl/certs:ro \
-          --volume=${ETCD_SSL_DIR}:/etc/ssl/etcd:ro \
-          quay.io/coreos/flannel:${FLANNEL_VER} /opt/bin/flanneld --ip-masq=true
-        # Update docker options
-        ExecStartPost=/usr/bin/docker run --net=host --rm -v /run:/run \
-          quay.io/coreos/flannel:${FLANNEL_VER} \
-          /opt/bin/mk-docker-opts.sh -d /run/flannel_docker_opts.env -i
-    - name: docker.service
+    - name: "flanneld.service"
+      command: start
       drop-ins:
-        - name: "40-flannel.conf"
+        - name: 50-network-config.conf
+          content: |
+            [Unit]
+            Requires=etcd2.service
+            [Service]
+            ExecStartPre=/usr/bin/etcdctl set /coreos.com/network/config '{"Network":"10.2.0.0/16", "Backend": {"Type": "vxlan"}}'
+    - name: "docker.service"
+      command: start
+      drop-ins:
+        - name: 40-flannel.conf
           content: |
             [Unit]
             Requires=flanneld.service
             After=flanneld.service
-            [Service]
-            Restart=always
-            Restart=on-failure
     - name: kubelet.service
       command: start
       content: |

--- a/config/providers/gce/master.yaml
+++ b/config/providers/gce/master.yaml
@@ -634,56 +634,23 @@ coreos:
   units:
     - name: etcd2.service
       command: start
-    - name: flanneld.service
-      content: |
-        [Unit]
-        Description=Network fabric for containers
-        Documentation=https://github.com/coreos/flannel
-        Requires=early-docker.service
-        After=etcd.service etcd2.service early-docker.service
-        Before=early-docker.target
-        [Service]
-        Type=notify
-        Restart=always
-        RestartSec=5
-        Environment="TMPDIR=/var/tmp/"
-        Environment="DOCKER_HOST=unix:///var/run/early-docker.sock"
-        Environment="FLANNEL_VER=0.5.5"
-        Environment="ETCD_SSL_DIR=/etc/ssl/etcd"
-        Environment="FLANNEL_ENV_FILE=/run/flannel/options.env"
-        LimitNOFILE=40000
-        LimitNPROC=1048576
-        ExecStartPre=/sbin/modprobe ip_tables
-        ExecStartPre=/usr/bin/mkdir -p /run/flannel
-        ExecStartPre=/usr/bin/mkdir -p ${ETCD_SSL_DIR}
-        ExecStartPre=-/usr/bin/touch ${FLANNEL_ENV_FILE}
-        ExecStart=/usr/libexec/sdnotify-proxy /run/flannel/sd.sock \
-          /usr/bin/docker run --net=host --privileged=true --rm \
-          --volume=/run/flannel:/run/flannel \
-          --env=NOTIFY_SOCKET=/run/flannel/sd.sock \
-          --env-file=${FLANNEL_ENV_FILE} \
-          --volume=/usr/share/ca-certificates:/etc/ssl/certs:ro \
-          --volume=${ETCD_SSL_DIR}:/etc/ssl/etcd:ro \
-          quay.io/coreos/flannel:${FLANNEL_VER} /opt/bin/flanneld --ip-masq=true
-        # Update docker options
-        ExecStartPost=/usr/bin/docker run --net=host --rm -v /run:/run \
-          quay.io/coreos/flannel:${FLANNEL_VER} \
-          /opt/bin/mk-docker-opts.sh -d /run/flannel_docker_opts.env -i
+    - name: "flanneld.service"
+      command: start
       drop-ins:
-        - name: "50-ExecStartPre-flannel-network.conf"
+        - name: 50-network-config.conf
           content: |
+            [Unit]
+            Requires=etcd2.service
             [Service]
-            ExecStartPre=/usr/bin/curl -X PUT -d "value={\"Network\":\"10.2.0.0/16\",\"Backend\":{\"Type\":\"vxlan\"}}" http://127.0.0.1:2379/v2/keys/coreos.com/network/config
-    - name: docker.service
+            ExecStartPre=/usr/bin/etcdctl set /coreos.com/network/config '{"Network":"10.2.0.0/16", "Backend": {"Type": "vxlan"}}'
+    - name: "docker.service"
+      command: start
       drop-ins:
-        - name: "40-flannel.conf"
+        - name: 40-flannel.conf
           content: |
             [Unit]
             Requires=flanneld.service
             After=flanneld.service
-            [Service]
-            Restart=always
-            Restart=on-failure
     - name: kubelet.service
       command: start
       content: |

--- a/config/providers/gce/minion.yaml
+++ b/config/providers/gce/minion.yaml
@@ -104,51 +104,23 @@ coreos:
     etcd_endpoints: http://{{ .Kube.GCEConfig.MasterPrivateIP }}:2379
 
   units:
-    - name: flanneld.service
-      content: |
-        [Unit]
-        Description=Network fabric for containers
-        Documentation=https://github.com/coreos/flannel
-        Requires=early-docker.service
-        After=etcd.service etcd2.service early-docker.service
-        Before=early-docker.target
-        [Service]
-        Type=notify
-        Restart=always
-        RestartSec=5
-        Environment="TMPDIR=/var/tmp/"
-        Environment="DOCKER_HOST=unix:///var/run/early-docker.sock"
-        Environment="FLANNEL_VER=0.5.5"
-        Environment="ETCD_SSL_DIR=/etc/ssl/etcd"
-        Environment="FLANNEL_ENV_FILE=/run/flannel/options.env"
-        LimitNOFILE=40000
-        LimitNPROC=1048576
-        ExecStartPre=/sbin/modprobe ip_tables
-        ExecStartPre=/usr/bin/mkdir -p /run/flannel
-        ExecStartPre=/usr/bin/mkdir -p ${ETCD_SSL_DIR}
-        ExecStartPre=-/usr/bin/touch ${FLANNEL_ENV_FILE}
-        ExecStart=/usr/libexec/sdnotify-proxy /run/flannel/sd.sock \
-          /usr/bin/docker run --net=host --privileged=true --rm \
-          --volume=/run/flannel:/run/flannel \
-          --env=NOTIFY_SOCKET=/run/flannel/sd.sock \
-          --env-file=${FLANNEL_ENV_FILE} \
-          --volume=/usr/share/ca-certificates:/etc/ssl/certs:ro \
-          --volume=${ETCD_SSL_DIR}:/etc/ssl/etcd:ro \
-          quay.io/coreos/flannel:${FLANNEL_VER} /opt/bin/flanneld --ip-masq=true
-        # Update docker options
-        ExecStartPost=/usr/bin/docker run --net=host --rm -v /run:/run \
-          quay.io/coreos/flannel:${FLANNEL_VER} \
-          /opt/bin/mk-docker-opts.sh -d /run/flannel_docker_opts.env -i
-    - name: docker.service
+    - name: "flanneld.service"
+      command: start
       drop-ins:
-        - name: "40-flannel.conf"
+        - name: 50-network-config.conf
+          content: |
+            [Unit]
+            Requires=etcd2.service
+            [Service]
+            ExecStartPre=/usr/bin/etcdctl set /coreos.com/network/config '{"Network":"10.2.0.0/16", "Backend": {"Type": "vxlan"}}'
+    - name: "docker.service"
+      command: start
+      drop-ins:
+        - name: 40-flannel.conf
           content: |
             [Unit]
             Requires=flanneld.service
             After=flanneld.service
-            [Service]
-            Restart=always
-            Restart=on-failure
     - name: kubelet.service
       command: start
       content: |

--- a/config/providers/openstack/master.yaml
+++ b/config/providers/openstack/master.yaml
@@ -610,56 +610,23 @@ coreos:
   units:
     - name: etcd2.service
       command: start
-    - name: flanneld.service
-      content: |
-        [Unit]
-        Description=Network fabric for containers
-        Documentation=https://github.com/coreos/flannel
-        Requires=early-docker.service
-        After=etcd.service etcd2.service early-docker.service
-        Before=early-docker.target
-        [Service]
-        Type=notify
-        Restart=always
-        RestartSec=5
-        Environment="TMPDIR=/var/tmp/"
-        Environment="DOCKER_HOST=unix:///var/run/early-docker.sock"
-        Environment="FLANNEL_VER=0.5.5"
-        Environment="ETCD_SSL_DIR=/etc/ssl/etcd"
-        Environment="FLANNEL_ENV_FILE=/run/flannel/options.env"
-        LimitNOFILE=40000
-        LimitNPROC=1048576
-        ExecStartPre=/sbin/modprobe ip_tables
-        ExecStartPre=/usr/bin/mkdir -p /run/flannel
-        ExecStartPre=/usr/bin/mkdir -p ${ETCD_SSL_DIR}
-        ExecStartPre=-/usr/bin/touch ${FLANNEL_ENV_FILE}
-        ExecStart=/usr/libexec/sdnotify-proxy /run/flannel/sd.sock \
-          /usr/bin/docker run --net=host --privileged=true --rm \
-          --volume=/run/flannel:/run/flannel \
-          --env=NOTIFY_SOCKET=/run/flannel/sd.sock \
-          --env-file=${FLANNEL_ENV_FILE} \
-          --volume=/usr/share/ca-certificates:/etc/ssl/certs:ro \
-          --volume=${ETCD_SSL_DIR}:/etc/ssl/etcd:ro \
-          quay.io/coreos/flannel:${FLANNEL_VER} /opt/bin/flanneld --ip-masq=true
-        # Update docker options
-        ExecStartPost=/usr/bin/docker run --net=host --rm -v /run:/run \
-          quay.io/coreos/flannel:${FLANNEL_VER} \
-          /opt/bin/mk-docker-opts.sh -d /run/flannel_docker_opts.env -i
+    - name: "flanneld.service"
+      command: start
       drop-ins:
-        - name: "50-ExecStartPre-flannel-network.conf"
+        - name: 50-network-config.conf
           content: |
+            [Unit]
+            Requires=etcd2.service
             [Service]
-            ExecStartPre=/usr/bin/curl -X PUT -d "value={\"Network\":\"10.2.0.0/16\",\"Backend\":{\"Type\":\"vxlan\"}}" http://127.0.0.1:2379/v2/keys/coreos.com/network/config
-    - name: docker.service
+            ExecStartPre=/usr/bin/etcdctl set /coreos.com/network/config '{"Network":"10.2.0.0/16", "Backend": {"Type": "vxlan"}}'
+    - name: "docker.service"
+      command: start
       drop-ins:
-        - name: "40-flannel.conf"
+        - name: 40-flannel.conf
           content: |
             [Unit]
             Requires=flanneld.service
             After=flanneld.service
-            [Service]
-            Restart=always
-            Restart=on-failure
     - name: kubelet.service
       command: start
       content: |

--- a/config/providers/openstack/minion.yaml
+++ b/config/providers/openstack/minion.yaml
@@ -110,50 +110,22 @@ coreos:
 
   units:
     - name: flanneld.service
-      content: |
-        [Unit]
-        Description=Network fabric for containers
-        Documentation=https://github.com/coreos/flannel
-        Requires=early-docker.service
-        After=etcd.service etcd2.service early-docker.service
-        Before=early-docker.target
-        [Service]
-        Type=notify
-        Restart=always
-        RestartSec=5
-        Environment="TMPDIR=/var/tmp/"
-        Environment="DOCKER_HOST=unix:///var/run/early-docker.sock"
-        Environment="FLANNEL_VER=0.5.5"
-        Environment="ETCD_SSL_DIR=/etc/ssl/etcd"
-        Environment="FLANNEL_ENV_FILE=/run/flannel/options.env"
-        LimitNOFILE=40000
-        LimitNPROC=1048576
-        ExecStartPre=/sbin/modprobe ip_tables
-        ExecStartPre=/usr/bin/mkdir -p /run/flannel
-        ExecStartPre=/usr/bin/mkdir -p ${ETCD_SSL_DIR}
-        ExecStartPre=-/usr/bin/touch ${FLANNEL_ENV_FILE}
-        ExecStart=/usr/libexec/sdnotify-proxy /run/flannel/sd.sock \
-          /usr/bin/docker run --net=host --privileged=true --rm \
-          --volume=/run/flannel:/run/flannel \
-          --env=NOTIFY_SOCKET=/run/flannel/sd.sock \
-          --env-file=${FLANNEL_ENV_FILE} \
-          --volume=/usr/share/ca-certificates:/etc/ssl/certs:ro \
-          --volume=${ETCD_SSL_DIR}:/etc/ssl/etcd:ro \
-          quay.io/coreos/flannel:${FLANNEL_VER} /opt/bin/flanneld --ip-masq=true
-        # Update docker options
-        ExecStartPost=/usr/bin/docker run --net=host --rm -v /run:/run \
-          quay.io/coreos/flannel:${FLANNEL_VER} \
-          /opt/bin/mk-docker-opts.sh -d /run/flannel_docker_opts.env -i
-    - name: docker.service
+      command: start
       drop-ins:
-        - name: "40-flannel.conf"
+        - name: 50-network-config.conf
+          content: |
+            [Unit]
+            Requires=etcd2.service
+            [Service]
+            ExecStartPre=/usr/bin/etcdctl set /coreos.com/network/config '{"Network":"10.2.0.0/16", "Backend": {"Type": "vxlan"}}'
+    - name: "docker.service"
+      command: start
+      drop-ins:
+        - name: 40-flannel.conf
           content: |
             [Unit]
             Requires=flanneld.service
             After=flanneld.service
-            [Service]
-            Restart=always
-            Restart=on-failure
     - name: kubelet.service
       command: start
       content: |


### PR DESCRIPTION
This update fixes a conflict with newer versions of Core-OS
and Supergiant drop-in modifications to the flannel and docker service.

Fixes #201