### PR TITLE
Version in CLI struct was taking precidence over cli.App

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -44,15 +44,13 @@ type CLI struct {
 	*cli.App
 	Client  func(*cli.Context) *client.Client
 	Stdin   *os.File
-	Version string
 }
 
 func New(clientFn func(*cli.Context) *client.Client, stdin *os.File, version string) *CLI {
-	sgcli := &CLI{cli.NewApp(), clientFn, stdin, version}
+	sgcli := &CLI{cli.NewApp(), clientFn, stdin}
 
 	sgcli.Name = "supergiant"
 	sgcli.Usage = "Supergiant CLI " + version
-	// TODO for whatever reason the version always reports 0.0.0
 	sgcli.Version = version
 
 	sgcli.Commands = []cli.Command{


### PR DESCRIPTION
version always reported 0.0.0 because you were setting the Version on the CLI struct, not the underlying cli.App.