### PR TITLE
Openstack Update and Kubernetes version based templates.

### DIFF
--- a/config/providers/common/1.5.7/master.yaml
+++ b/config/providers/common/1.5.7/master.yaml
@@ -1,0 +1,612 @@
+#cloud-config
+
+hostname: "{{ .MasterName }}"
+ssh_authorized_keys:
+  - "{{ .SSHPubKey }}"
+write_files:
+  - path: "/opt/bin/download-k8s-binary"
+    permissions: "0755"
+    content: |
+      #!/bin/bash
+      source /etc/environment
+      K8S_VERSION=v{{ .KubernetesVersion }}
+      mkdir -p /opt/bin
+      curl -sSL -o /opt/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION}/bin/linux/amd64/kubectl
+      chmod +x /opt/bin/$FILE
+      chmod +x /opt/bin/kubectl
+
+
+      ## Install Tiller ##
+      wget http://storage.googleapis.com/kubernetes-helm/helm-v2.1.3-linux-amd64.tar.gz --directory-prefix=/tmp/
+      tar -C /tmp -xvf /tmp/helm-v2.1.3-linux-amd64.tar.gz
+      cp /tmp/linux-amd64/helm /opt/bin/helm
+      chmod +x /opt/bin/helm
+      /opt/bin/helm init
+
+      ## Install CNI
+
+      curl -sSL -o /opt/bin/cni.tar.gz https://storage.googleapis.com/kubernetes-release/network-plugins/cni-07a8a28637e97b22eb8dfe710eeae1344f69d16e.tar.gz
+      tar xzf "/opt/bin/cni.tar.gz" -C "/opt/bin" --overwrite
+      mv /opt/bin/bin/* /opt/bin
+      rm -r /opt/bin/bin/
+      rm -f "/opt/bin/cni.tar.gz"
+
+      openssl genrsa -out /etc/kubernetes/ssl/ca-key.pem 2048
+      openssl req -x509 -new -nodes -key /etc/kubernetes/ssl/ca-key.pem -days 10000 -out /etc/kubernetes/ssl/ca.pem -subj "/CN=kube-ca"
+      sed -e "s/\${MASTER_HOST}/`curl ipinfo.io/ip`/" < /etc/kubernetes/ssl/openssl.cnf.template > /etc/kubernetes/ssl/openssl.cnf.public
+      sed -e "s/\${PRIVATE_HOST}/$COREOS_PRIVATE_IPV4/" < /etc/kubernetes/ssl/openssl.cnf.public > /etc/kubernetes/ssl/openssl.cnf
+      openssl genrsa -out /etc/kubernetes/ssl/apiserver-key.pem 2048
+      openssl req -new -key /etc/kubernetes/ssl/apiserver-key.pem -out /etc/kubernetes/ssl/apiserver.csr -subj "/CN=kube-apiserver" -config /etc/kubernetes/ssl/openssl.cnf
+      openssl x509 -req -in /etc/kubernetes/ssl/apiserver.csr -CA /etc/kubernetes/ssl/ca.pem -CAkey /etc/kubernetes/ssl/ca-key.pem -CAcreateserial -out /etc/kubernetes/ssl/apiserver.pem -days 365 -extensions v3_req -extfile /etc/kubernetes/ssl/openssl.cnf
+      openssl genrsa -out /etc/kubernetes/ssl/worker-key.pem 2048
+      openssl req -new -key /etc/kubernetes/ssl/worker-key.pem -out /etc/kubernetes/ssl/worker.csr -subj "/CN=kube-worker"
+      openssl x509 -req -in /etc/kubernetes/ssl/worker.csr -CA /etc/kubernetes/ssl/ca.pem -CAkey /etc/kubernetes/ssl/ca-key.pem -CAcreateserial -out /etc/kubernetes/ssl/worker.pem -days 365
+      openssl genrsa -out /etc/kubernetes/ssl/admin-key.pem 2048
+      openssl req -new -key /etc/kubernetes/ssl/admin-key.pem -out /etc/kubernetes/ssl/admin.csr -subj "/CN=kube-admin"
+      openssl x509 -req -in /etc/kubernetes/ssl/admin.csr -CA /etc/kubernetes/ssl/ca.pem -CAkey /etc/kubernetes/ssl/ca-key.pem -CAcreateserial -out /etc/kubernetes/ssl/admin.pem -days 365
+      chmod 600 /etc/kubernetes/ssl/*-key.pem
+      chown root:root /etc/kubernetes/ssl/*-key.pem
+  - path: "/opt/bin/kube-post-start.sh"
+    permissions: "0755"
+    content: |
+      #!/bin/bash
+      until $(curl --output /dev/null --silent --head --fail http://127.0.0.1:8080); do printf '.'; sleep 5; done
+      curl -XPOST -H 'Content-type: application/json' -d'{"apiVersion":"v1","kind":"Namespace","metadata":{"name":"kube-system"}}' http://127.0.0.1:8080/api/v1/namespaces
+      /opt/bin/kubectl config set-cluster default-cluster --server="127.0.0.1:8080"
+      /opt/bin/kubectl config set-context default-system --cluster=default-cluster --user=default-admin
+      /opt/bin/kubectl config use-context default-system
+      /opt/bin/kubectl create -f /etc/kubernetes/addons/kube-dns.yaml
+      /opt/bin/kubectl create -f /etc/kubernetes/addons/cluster-monitoring
+      /opt/bin/helm init
+  - path: "/etc/kubernetes/ssl/openssl.cnf.template"
+    permissions: "0755"
+    content: |
+      [req]
+      req_extensions = v3_req
+      distinguished_name = req_distinguished_name
+      [req_distinguished_name]
+      [ v3_req ]
+      basicConstraints = CA:FALSE
+      keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+      subjectAltName = @alt_names
+      [alt_names]
+      DNS.1 = kubernetes
+      DNS.2 = kubernetes.default
+      IP.1 = 10.3.0.1
+      IP.2 = ${MASTER_HOST}
+      IP.3 = ${PRIVATE_HOST}
+  - path: "/etc/kubernetes/ssl/basic_auth.csv"
+    permissions: "0644"
+    content: |
+      {{ .Password }},{{ .Username }},admin
+  - path: "/etc/kubernetes/ssl/known_tokens.csv"
+    permissions: "0644"
+    content: |
+      {{ .Password }},kubelet,kubelet
+      {{ .Password }},kube_proxy,kube_proxy
+      {{ .Password }},system:scheduler,system:scheduler
+      {{ .Password }},system:controller_manager,system:controller_manager
+      {{ .Password }},system:logging,system:logging
+      {{ .Password }},system:monitoring,system:monitoring
+      {{ .Password }},system:dns,system:dns
+{{- .CustomFiles }}
+  - path: "/etc/kubernetes/addons/namespace.yaml"
+    permissions: "0644"
+    content: |
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: kube-system
+  - path: "/var/lib/kubelet/kubeconfig"
+    permissions: "0400"
+    content: |
+      apiVersion: v1
+      kind: Config
+      users:
+      - name: kubelet
+        user:
+          token: {{ .Password }}
+      clusters:
+      - name: local
+        cluster:
+           insecure-skip-tls-verify: true
+      contexts:
+      - context:
+          cluster: local
+          user: kubelet
+        name: service-account-context
+      current-context: service-account-context
+  - path: "/etc/kubernetes/manifests/kube-apiserver.yaml"
+    permissions: "0644"
+    owner: "root"
+    content: |
+      apiVersion: v1
+      kind: Pod
+      metadata:
+        name: kube-apiserver
+        namespace: kube-system
+      spec:
+        hostNetwork: true
+        containers:
+        - name: kube-apiserver
+          image: gcr.io/google_containers/hyperkube:v{{ .KubernetesVersion }}
+          command:
+          - /hyperkube
+          - apiserver
+          - --bind-address=0.0.0.0
+          - --etcd-servers=http://127.0.0.1:2379
+          - --allow-privileged=true
+          - --service-cluster-ip-range=10.3.0.0/24
+          - --secure-port=443
+          - --advertise-address=$private_ipv4
+          - --admission-control=NamespaceLifecycle,NamespaceExists,LimitRanger,ServiceAccount,ResourceQuota
+          - --tls-cert-file=/etc/kubernetes/ssl/apiserver.pem
+          - --tls-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem
+          - --client-ca-file=/etc/kubernetes/ssl/ca.pem
+          - --service-account-key-file=/etc/kubernetes/ssl/apiserver-key.pem
+          - --basic-auth-file=/etc/kubernetes/ssl/basic_auth.csv
+          - --token-auth-file=/etc/kubernetes/ssl/known_tokens.csv
+          - --kubelet-preferred-address-types=InternalIP,Hostname,ExternalIP
+          {{- .ProviderString }}
+          ports:
+          - containerPort: 443
+            hostPort: 443
+            name: https
+          - containerPort: 8080
+            hostPort: 8080
+            name: local
+          volumeMounts:
+          - mountPath: /etc/kubernetes/ssl
+            name: ssl-certs-kubernetes
+            readOnly: true
+          - mountPath: /etc/kubernetes/addons
+            name: api-addons-kubernetes
+            readOnly: true
+          - mountPath: /etc/ssl/certs
+            name: ssl-certs-host
+            readOnly: true
+        volumes:
+        - hostPath:
+            path: /etc/kubernetes/ssl
+          name: ssl-certs-kubernetes
+        - hostPath:
+            path: /etc/kubernetes/addons
+          name: api-addons-kubernetes
+        - hostPath:
+            path: /usr/share/ca-certificates
+          name: ssl-certs-host
+  - path: "/etc/kubernetes/manifests/kube-proxy.yaml"
+    permissions: "0644"
+    owner: "root"
+    content: |
+      apiVersion: v1
+      kind: Pod
+      metadata:
+        name: kube-proxy
+        namespace: kube-system
+      spec:
+        hostNetwork: true
+        containers:
+        - name: kube-proxy
+          image: gcr.io/google_containers/hyperkube:v{{ .KubernetesVersion }}
+          command:
+          - /hyperkube
+          - proxy
+          - --master=http://127.0.0.1:8080
+          - --proxy-mode=iptables
+          securityContext:
+            privileged: true
+          volumeMounts:
+          - mountPath: /etc/ssl/certs
+            name: ssl-certs-host
+            readOnly: true
+        volumes:
+        - hostPath:
+            path: /usr/share/ca-certificates
+          name: ssl-certs-host
+  - path: "/etc/kubernetes/addons/cluster-monitoring/heapster-controller.yaml"
+    permissions: "0644"
+    owner: "root"
+    content: |
+      apiVersion: v1
+      kind: ReplicationController
+      metadata:
+        name: heapster-v11
+        namespace: kube-system
+        labels:
+          k8s-app: heapster
+          version: v11
+          kubernetes.io/cluster-service: "true"
+      spec:
+        replicas: 1
+        selector:
+          k8s-app: heapster
+          version: v11
+        template:
+          metadata:
+            labels:
+              k8s-app: heapster
+              version: v11
+              kubernetes.io/cluster-service: "true"
+          spec:
+            containers:
+              - image: gcr.io/google_containers/heapster:{{ .HeapsterVersion }}
+                name: heapster
+                resources:
+                  limits:
+                    cpu: 100m
+                    memory: 212Mi
+                command:
+                  - /heapster
+                  - --source=kubernetes
+                  - --sink=influxdb:http://monitoring-influxdb:8086
+                  - --metric_resolution={{ .HeapsterMetricResolution }}
+  - path: "/etc/kubernetes/addons/cluster-monitoring/heapster-service.yaml"
+    permissions: "0644"
+    owner: "root"
+    content: |
+      kind: Service
+      apiVersion: v1
+      metadata:
+        name: heapster
+        namespace: kube-system
+        labels:
+          kubernetes.io/cluster-service: "true"
+          kubernetes.io/name: "Heapster"
+      spec:
+        ports:
+          - port: 80
+            targetPort: 8082
+        selector:
+          k8s-app: heapster
+  - path: "/etc/kubernetes/addons/cluster-monitoring/influxdb-grafana-controller.yaml"
+    permissions: "0644"
+    owner: "root"
+    content: |
+      apiVersion: v1
+      kind: ReplicationController
+      metadata:
+        name: monitoring-influxdb-grafana-v2
+        namespace: kube-system
+        labels:
+          k8s-app: influxGrafana
+          version: v2
+          kubernetes.io/cluster-service: "true"
+      spec:
+        replicas: 1
+        selector:
+          k8s-app: influxGrafana
+          version: v2
+        template:
+          metadata:
+            labels:
+              k8s-app: influxGrafana
+              version: v2
+              kubernetes.io/cluster-service: "true"
+          spec:
+            containers:
+              - image: gcr.io/google_containers/heapster_influxdb:v0.4
+                name: influxdb
+                resources:
+                  limits:
+                    cpu: 100m
+                    memory: 200Mi
+                ports:
+                  - containerPort: 8083
+                    hostPort: 8083
+                  - containerPort: 8086
+                    hostPort: 8086
+                volumeMounts:
+                - name: influxdb-persistent-storage
+                  mountPath: /data
+              - image: beta.gcr.io/google_containers/heapster_grafana:v2.1.1
+                name: grafana
+                env:
+                resources:
+                  limits:
+                    cpu: 100m
+                    memory: 100Mi
+                env:
+                  # This variable is required to setup templates in Grafana.
+                  - name: INFLUXDB_SERVICE_URL
+                    value: http://monitoring-influxdb:8086
+                    # The following env variables are required to make Grafana accessible via
+                    # the kubernetes api-server proxy. On production clusters, we recommend
+                    # removing these env variables, setup auth for grafana, and expose the grafana
+                    # service using a LoadBalancer or a public IP.
+                  - name: GF_AUTH_BASIC_ENABLED
+                    value: "false"
+                  - name: GF_AUTH_ANONYMOUS_ENABLED
+                    value: "true"
+                  - name: GF_AUTH_ANONYMOUS_ORG_ROLE
+                    value: Admin
+                  - name: GF_SERVER_ROOT_URL
+                    value: /api/v1/proxy/namespaces/kube-system/services/monitoring-grafana/
+                volumeMounts:
+                - name: grafana-persistent-storage
+                  mountPath: /var
+
+            volumes:
+            - name: influxdb-persistent-storage
+              emptyDir: {}
+            - name: grafana-persistent-storage
+              emptyDir: {}
+  - path: "/etc/kubernetes/addons/cluster-monitoring/influxdb-service.yaml"
+    permissions: "0644"
+    owner: "root"
+    content: |
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: monitoring-influxdb
+        namespace: kube-system
+        labels:
+          kubernetes.io/cluster-service: "true"
+          kubernetes.io/name: "InfluxDB"
+      spec:
+        ports:
+          - name: http
+            port: 8083
+            targetPort: 8083
+          - name: api
+            port: 8086
+            targetPort: 8086
+        selector:
+          k8s-app: influxGrafana
+  - path: "/etc/kubernetes/addons/kube-dns.yaml"
+    permissions: "0644"
+    owner: "root"
+    content: |
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: kube-dns
+        namespace: kube-system
+        labels:
+          k8s-app: kube-dns
+          kubernetes.io/cluster-service: "true"
+          kubernetes.io/name: "KubeDNS"
+      spec:
+        selector:
+          k8s-app: kube-dns
+        clusterIP: 10.3.0.10
+        ports:
+        - name: dns
+          port: 53
+          protocol: UDP
+        - name: dns-tcp
+          port: 53
+          protocol: TCP
+
+      ---
+
+      apiVersion: v1
+      kind: ReplicationController
+      metadata:
+        name: kube-dns-v11
+        namespace: kube-system
+        labels:
+          k8s-app: kube-dns
+          version: v11
+          kubernetes.io/cluster-service: "true"
+      spec:
+        replicas: 1
+        selector:
+          k8s-app: kube-dns
+          version: v11
+        template:
+          metadata:
+            labels:
+              k8s-app: kube-dns
+              version: v11
+              kubernetes.io/cluster-service: "true"
+          spec:
+            containers:
+            - name: etcd
+              image: gcr.io/google_containers/etcd:2.0.9
+              resources:
+                limits:
+                  cpu: 100m
+                  memory: 50Mi
+              command:
+              - /usr/local/bin/etcd
+              - -data-dir
+              - /var/etcd/data
+              - -listen-client-urls
+              - http://127.0.0.1:2379,http://127.0.0.1:4001
+              - -advertise-client-urls
+              - http://127.0.0.1:2379,http://127.0.0.1:4001
+              - -initial-cluster-token
+              - skydns-etcd
+              volumeMounts:
+              - name: etcd-storage
+                mountPath: /var/etcd/data
+            - name: kube2sky
+              image: gcr.io/google_containers/kube2sky:1.11
+              resources:
+                limits:
+                  cpu: 100m
+                  memory: 50Mi
+              args:
+              # command = "/kube2sky"
+              - -domain=cluster.local
+            - name: skydns
+              image: gcr.io/google_containers/skydns:2015-03-11-001
+              resources:
+                limits:
+                  cpu: 100m
+                  memory: 50Mi
+              args:
+              # command = "/skydns"
+              - -machines=http://localhost:4001
+              - -addr=0.0.0.0:53
+              - -domain=cluster.local.
+              ports:
+              - containerPort: 53
+                name: dns
+                protocol: UDP
+              - containerPort: 53
+                name: dns-tcp
+                protocol: TCP
+              livenessProbe:
+                httpGet:
+                  path: /healthz
+                  port: 8080
+                  scheme: HTTP
+                initialDelaySeconds: 30
+                timeoutSeconds: 5
+              readinessProbe:
+                httpGet:
+                  path: /healthz
+                  port: 8080
+                  scheme: HTTP
+                initialDelaySeconds: 1
+                timeoutSeconds: 5
+            - name: healthz
+              image: gcr.io/google_containers/exechealthz:1.0
+              resources:
+                limits:
+                  cpu: 10m
+                  memory: 20Mi
+              args:
+              - -cmd=nslookup kubernetes.default.svc.cluster.local localhost >/dev/null
+              - -port=8080
+              ports:
+              - containerPort: 8080
+                protocol: TCP
+            volumes:
+            - name: etcd-storage
+              emptyDir: {}
+            dnsPolicy: Default
+  - path: "/etc/kubernetes/manifests/kube-controller-manager.yaml"
+    permissions: "0644"
+    owner: "root"
+    content: |
+      apiVersion: v1
+      kind: Pod
+      metadata:
+        name: kube-controller-manager
+        namespace: kube-system
+      spec:
+        hostNetwork: true
+        containers:
+        - name: kube-controller-manager
+          image: gcr.io/google_containers/hyperkube:v{{ .KubernetesVersion }}
+          command:
+          - /hyperkube
+          - controller-manager
+          - --master=http://127.0.0.1:8080
+          - --service-account-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem
+          - --root-ca-file=/etc/kubernetes/ssl/ca.pem
+          - --v=2
+          - --cluster-cidr=10.244.0.0/14
+          - --allocate-node-cidrs=true
+          {{- .ProviderString }}
+          livenessProbe:
+            httpGet:
+              host: 127.0.0.1
+              path: /healthz
+              port: 10252
+            initialDelaySeconds: 15
+            timeoutSeconds: 1
+          volumeMounts:
+          - mountPath: /etc/kubernetes/ssl
+            name: ssl-certs-kubernetes
+            readOnly: true
+          - mountPath: /etc/ssl/certs
+            name: ssl-certs-host
+            readOnly: true
+        volumes:
+        - hostPath:
+            path: /etc/kubernetes/ssl
+          name: ssl-certs-kubernetes
+        - hostPath:
+            path: /usr/share/ca-certificates
+          name: ssl-certs-host
+  - path: "/etc/kubernetes/manifests/kube-scheduler.yaml"
+    permissions: "0644"
+    owner: "root"
+    content: |
+      apiVersion: v1
+      kind: Pod
+      metadata:
+        name: kube-scheduler
+        namespace: kube-system
+      spec:
+        hostNetwork: true
+        containers:
+        - name: kube-scheduler
+          image: gcr.io/google_containers/hyperkube:v{{ .KubernetesVersion }}
+          command:
+          - /hyperkube
+          - scheduler
+          - --master=http://127.0.0.1:8080
+          livenessProbe:
+            httpGet:
+              host: 127.0.0.1
+              path: /healthz
+              port: 10251
+            initialDelaySeconds: 15
+            timeoutSeconds: 1
+coreos:
+  update:
+    reboot-strategy: off
+  etcd2:
+    advertise-client-urls: http://$private_ipv4:2379
+    initial-advertise-peer-urls: http://$private_ipv4:2380
+    listen-client-urls: http://0.0.0.0:2379,http://0.0.0.0:4001
+    listen-peer-urls: http://0.0.0.0:2380
+    discovery: {{ .ETCDDiscoveryURL }}
+  flannel:
+    iface: $private_ipv4
+    etcd_endpoints: http://127.0.0.1:2379
+  units:
+    - name: etcd2.service
+      command: start
+    - name: "flanneld.service"
+      command: start
+      drop-ins:
+        - name: 50-network-config.conf
+          content: |
+            [Unit]
+            Requires=etcd2.service
+            [Service]
+            ExecStartPre=/usr/bin/etcdctl set /coreos.com/network/config '{"Network":"10.2.0.0/16", "Backend": {"Type": "vxlan"}}'
+    - name: "docker.service"
+      command: start
+      drop-ins:
+        - name: 40-flannel.conf
+          content: |
+            [Unit]
+            Requires=flanneld.service
+            After=flanneld.service
+    - name: kubelet.service
+      command: start
+      content: |
+        # /usr/lib64/systemd/system/kubelet.service
+        [Unit]
+        Description=Kubernetes Kubelet
+        [Service]
+        Environment=KUBELET_IMAGE_TAG=v{{ .KubernetesVersion }}_coreos.0
+        Environment="RKT_RUN_ARGS=--volume=resolv,kind=host,source=/etc/resolv.conf \
+          --mount volume=resolv,target=/etc/resolv.conf \
+          --uuid-file-save=/var/run/kubelet-pod.uuid"
+        ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/run/kubelet-pod.uuid
+        ExecStartPre=/bin/bash -c "/opt/bin/download-k8s-binary"
+        ExecStartPost=/bin/bash -c "/opt/bin/kube-post-start.sh"
+        ExecStart=/usr/lib/coreos/kubelet-wrapper \
+         --api-servers=http://127.0.0.1:8080 \
+         --v=2 \
+         --allow-privileged=true \
+         --cadvisor-port=0 \
+         --pod-manifest-path=/etc/kubernetes/manifests \
+         --cluster-dns=10.3.0.10 \
+         --cluster_domain=cluster.local \
+         {{- .KubeProviderString }}
+         --register-node=false
+        ExecStop=-/usr/bin/rkt stop --uuid-file=/var/run/kubelet-pod.uuid
+        Restart=on-failure
+        TimeoutSec=300
+        RestartSec=5
+        [Install]
+        WantedBy=multi-user.target

--- a/config/providers/common/1.5.7/minion.yaml
+++ b/config/providers/common/1.5.7/minion.yaml
@@ -1,0 +1,160 @@
+#cloud-config
+
+hostname: "{{ .Name }}"
+ssh_authorized_keys:
+  - "{{ .Kube.SSHPubKey }}"
+write_files:
+  - path: "/opt/bin/download-k8s-binary"
+    permissions: "0755"
+    content: |
+      #!/bin/bash
+      source /etc/environment
+      K8S_VERSION=v{{ .Kube.KubernetesVersion }}
+      mkdir -p /opt/bin
+      mkdir /etc/multipath/
+      touch /etc/multipath/bindings
+      curl -sSL -o /opt/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION}/bin/linux/amd64/kubectl
+      chmod +x /opt/bin/$FILE
+      chmod +x /opt/bin/kubectl
+
+      curl -sSL -o /opt/bin/cni.tar.gz https://storage.googleapis.com/kubernetes-release/network-plugins/cni-07a8a28637e97b22eb8dfe710eeae1344f69d16e.tar.gz
+      tar xzf "/opt/bin/cni.tar.gz" -C "/opt/bin" --overwrite
+      mv /opt/bin/bin/* /opt/bin
+      rm -r /opt/bin/bin/
+      rm -f "/opt/bin/cni.tar.gz"
+
+      cd /opt/bin/
+      git clone https://github.com/packethost/packet-block-storage.git
+      cd packet-block-storage
+      chmod 755 ./*
+      /opt/bin/packet-block-storage/packet-block-storage-attach
+
+      cd /tmp
+      wget https://github.com/digitalocean/doctl/releases/download/v1.4.0/doctl-1.4.0-linux-amd64.tar.gz
+      tar xf /tmp/doctl-1.4.0-linux-amd64.tar.gz
+      sudo mv /tmp/doctl /opt/bin/
+  - path: "/etc/kubernetes/manifests/kube-proxy.yaml"
+    permissions: "0644"
+    owner: "root"
+    content: |
+      apiVersion: v1
+      kind: Pod
+      metadata:
+        name: kube-proxy
+        namespace: kube-system
+      spec:
+        hostNetwork: true
+        containers:
+        - name: kube-proxy
+          image: gcr.io/google_containers/hyperkube:v{{ .Kube.KubernetesVersion }}
+          command:
+          - /hyperkube
+          - proxy
+          - --master=https://{{ .Kube.MasterPrivateIP }}
+          - --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml
+          - --proxy-mode=iptables
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - mountPath: /etc/ssl/certs
+              name: "ssl-certs"
+            - mountPath: /etc/kubernetes/worker-kubeconfig.yaml
+              name: "kubeconfig"
+              readOnly: true
+            - mountPath: /etc/kubernetes/ssl
+              name: "etc-kube-ssl"
+              readOnly: true
+        volumes:
+          - name: "ssl-certs"
+            hostPath:
+              path: "/usr/share/ca-certificates"
+          - name: "kubeconfig"
+            hostPath:
+              path: "/etc/kubernetes/worker-kubeconfig.yaml"
+          - name: "etc-kube-ssl"
+            hostPath:
+              path: "/etc/kubernetes/ssl"
+{{- .Kube.CustomFiles }}
+  - path: "/etc/kubernetes/worker-kubeconfig.yaml"
+    permissions: "0644"
+    owner: "root"
+    content: |
+      apiVersion: v1
+      kind: Config
+      users:
+      - name: kubelet
+        user:
+          token: {{ .Kube.Password }}
+      clusters:
+      - name: local
+        cluster:
+           insecure-skip-tls-verify: true
+      contexts:
+      - context:
+          cluster: local
+          user: kubelet
+        name: service-account-context
+      current-context: service-account-context
+coreos:
+  update:
+    reboot-strategy: off
+  flannel:
+    iface: $COREOS_PRIVATE_IPV4
+    etcd_endpoints: http://{{ .Kube.MasterPrivateIP }}:2379
+
+  units:
+    - name: "flanneld.service"
+      command: start
+      drop-ins:
+        - name: 50-network-config.conf
+          content: |
+            [Unit]
+            Requires=etcd2.service
+            [Service]
+            ExecStartPre=/usr/bin/etcdctl set /coreos.com/network/config '{"Network":"10.2.0.0/16", "Backend": {"Type": "vxlan"}}'
+    - name: "docker.service"
+      command: start
+      drop-ins:
+        - name: 40-flannel.conf
+          content: |
+            [Unit]
+            Requires=flanneld.service
+            After=flanneld.service
+    - name: iscsid.service
+      enable: true
+      command: start
+    - name: kubelet.service
+      command: start
+      content: |
+        # /usr/lib64/systemd/system/kubelet.service
+        [Unit]
+        Description=Kubernetes Kubelet
+        [Service]
+        Environment=KUBELET_VERSION=v{{ .Kube.KubernetesVersion }}_coreos.0
+        Environment="RKT_RUN_ARGS=--volume iscsiadm,kind=host,source=/usr/sbin/iscsiadm \
+          --mount volume=iscsiadm,target=/usr/sbin/iscsiadm \
+          --volume multipathcmd,kind=host,source=/usr/sbin/multipath \
+          --mount volume=multipathcmd,target=/usr/sbin/multipath \
+          --volume multipath,kind=host,source=/etc/multipath/ \
+          --mount volume=multipath,target=/etc/multipath/ \
+          --volume packet,kind=host,source=/opt/bin/packet-block-storage/ \
+          --mount volume=packet,target=/opt/bin/packet-block-storage/ \
+          --uuid-file-save=/var/run/kubelet-pod.uuid"
+        ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/run/kubelet-pod.uuid
+        ExecStartPre=/bin/bash -c "/opt/bin/download-k8s-binary kubelet"
+        ExecStart=/usr/lib/coreos/kubelet-wrapper \
+          --allow-privileged=true \
+          --api_servers=https://{{ .Kube.MasterPrivateIP }} \
+          --cluster-dns=10.3.0.10 \
+          --cluster_domain=cluster.local \
+          --pod-manifest-path=/etc/kubernetes/manifests \
+          --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml \
+          --volume-plugin-dir=/etc/kubernetes/volumeplugins \
+          {{- .Kube.KubeProviderString }}
+          --register-node=true
+        ExecStop=-/usr/bin/rkt stop --uuid-file=/var/run/kubelet-pod.uuid
+        Restart=on-failure
+        TimeoutSec=300
+        RestartSec=5
+        [Install]
+        WantedBy=multi-user.target

--- a/pkg/model/kube.go
+++ b/pkg/model/kube.go
@@ -28,7 +28,7 @@ type Kube struct {
 	Name string `json:"name" validate:"nonzero,max=12,regexp=^[a-z]([-a-z0-9]*[a-z0-9])?$" gorm:"not null;unique_index" sg:"immutable"`
 	// Kubernetes
 	KubernetesVersion string `json:"kubernetes_version" validate:"nonzero" sg:"default=1.5.7"`
-	SSHPubKey         string `json:"ssh_pub_key" validate:"nonzero"`
+	SSHPubKey         string `json:"ssh_pub_key"`
 	ETCDDiscoveryURL  string `json:"etcd_discovery_url" sg:"readonly"`
 
 	// Kubernetes Master

--- a/pkg/model/kube.go
+++ b/pkg/model/kube.go
@@ -26,8 +26,22 @@ type Kube struct {
 	HelmReleases []*HelmRelease `json:"helm_releases,omitempty" gorm:"ForeignKey:KubeName;AssociationForeignKey:Name"`
 
 	Name string `json:"name" validate:"nonzero,max=12,regexp=^[a-z]([-a-z0-9]*[a-z0-9])?$" gorm:"not null;unique_index" sg:"immutable"`
+	// Kubernetes
+	KubernetesVersion string `json:"kubernetes_version" validate:"nonzero" sg:"default=1.5.7"`
+	SSHPubKey         string `json:"ssh_pub_key" validate:"nonzero"`
+	ETCDDiscoveryURL  string `json:"etcd_discovery_url" sg:"readonly"`
 
-	MasterNodeSize string `json:"master_node_size" validate:"nonzero" sg:"immutable"`
+	// Kubernetes Master
+	MasterNodeSize     string   `json:"master_node_size" validate:"nonzero" sg:"immutable"`
+	MasterID           string   `json:"master_id" sg:"readonly"`
+	MasterPrivateIP    string   `json:"master_private_ip" sg:"readonly"`
+	KubeMasterCount    int      `json:"kube_master_count"`
+	MasterNodes        []string `json:"master_nodes" gorm:"-" sg:"store_as_json_in=MasterNodesJSON"`
+	MasterNodesJSON    []byte   `json:"-"`
+	MasterName         string   `json:"master_name" sg:"readonly"`
+	CustomFiles        string   `json:"custom_files" sg:"readonly"`
+	ProviderString     string   `json:"provider_string" sg:"readonly"`
+	KubeProviderString string   `json:"Kube_provider_string" sg:"readonly"`
 
 	NodeSizes     []string `json:"node_sizes" gorm:"-" validate:"min=1" sg:"store_as_json_in=NodeSizesJSON"`
 	NodeSizesJSON []byte   `json:"-" gorm:"not null"`
@@ -109,17 +123,14 @@ type DOKubeConfig struct {
 // OSKubeConfig holds do specific information about Open Stack based KUbernetes clusters.
 type OSKubeConfig struct {
 	Region             string `json:"region" validate:"nonzero"`
-	SSHPubKey          string `json:"ssh_pub_key" validate:"nonzero"`
 	PrivateSubnetRange string `json:"private_subnet_ip_range" validate:"nonzero" sg:"default=172.20.0.0/24"`
 	PublicGatwayID     string `json:"public_gateway_id" validate:"nonzero" sg:"default=disabled"`
 
-	MasterID        string `json:"master_id" sg:"readonly"`
-	MasterPrivateIP string `json:"master_private_ip" sg:"readonly"`
-	NetworkID       string `json:"network_id" sg:"readonly"`
-	SubnetID        string `json:"subnet_id" sg:"readonly"`
-	RouterID        string `json:"router_id" sg:"readonly"`
-	FloatingIPID    string `json:"floating_ip_id" sg:"readonly"`
-	ImageName       string `json:"image_name" validate:"nonzero"`
+	NetworkID    string `json:"network_id" sg:"readonly"`
+	SubnetID     string `json:"subnet_id" sg:"readonly"`
+	RouterID     string `json:"router_id" sg:"readonly"`
+	FloatingIPID string `json:"floating_ip_id" sg:"readonly"`
+	ImageName    string `json:"image_name" validate:"nonzero"`
 }
 
 // GCEKubeConfig holds do specific information about DO based KUbernetes clusters.

--- a/pkg/provider/openstack/create_kube.go
+++ b/pkg/provider/openstack/create_kube.go
@@ -23,7 +23,7 @@ import (
 	"github.com/supergiant/supergiant/pkg/util"
 )
 
-// CreateKube creates a new DO kubernetes cluster.
+// CreateKube creates a new kubernetes cluster.
 func (p *Provider) CreateKube(m *model.Kube, action *core.Action) error {
 
 	// Initialize steps
@@ -105,10 +105,9 @@ func (p *Provider) CreateKube(m *model.Kube, action *core.Action) error {
 	// save the token
 	m.ETCDDiscoveryURL = url
 
-	// Proceedures
+	// Procedures
 	// Check for image.
 	procedure.AddStep("Checking that a CoreOS image exists...", func() error {
-		// Create network
 		_, err = images.IDFromName(computeClient, "CoreOS")
 		if err != nil {
 			return err
@@ -154,7 +153,7 @@ func (p *Provider) CreateKube(m *model.Kube, action *core.Action) error {
 		return nil
 	})
 
-	// Network
+	// Router
 	procedure.AddStep("Creating Kubernetes Router...", func() error {
 		err := err
 		// Create Router
@@ -211,7 +210,6 @@ func (p *Provider) CreateKube(m *model.Kube, action *core.Action) error {
 			if err = masterTemplate.Execute(&masterUserdata, m); err != nil {
 				return err
 			}
-			//fmt.Println(masterUserdata.String())
 			// Create Server
 
 			serverCreateOpts := servers.CreateOpts{

--- a/pkg/provider/openstack/create_kube.go
+++ b/pkg/provider/openstack/create_kube.go
@@ -1,0 +1,336 @@
+package openstack
+
+import (
+	"bytes"
+	"fmt"
+	"strconv"
+	"strings"
+	"text/template"
+	"time"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack"
+	floatingip "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/floatingips"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/images"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/floatingips"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/subnets"
+	"github.com/supergiant/supergiant/bindata"
+	"github.com/supergiant/supergiant/pkg/core"
+	"github.com/supergiant/supergiant/pkg/model"
+	"github.com/supergiant/supergiant/pkg/util"
+)
+
+// CreateKube creates a new DO kubernetes cluster.
+func (p *Provider) CreateKube(m *model.Kube, action *core.Action) error {
+
+	// Initialize steps
+	procedure := &core.Procedure{
+		Core:   p.Core,
+		Name:   "Create Kube",
+		Model:  m,
+		Action: action,
+	}
+
+	// fetch an authenticated provider.
+	authenticatedProvider, err := p.Client(m)
+	if err != nil {
+		return err
+	}
+
+	// Fetch compute client.
+	computeClient, err := openstack.NewComputeV2(authenticatedProvider, gophercloud.EndpointOpts{
+		Region: m.OpenStackConfig.Region,
+	})
+	if err != nil {
+		return err
+	}
+
+	// Fetch network client.
+	networkClient, err := openstack.NewNetworkV2(authenticatedProvider, gophercloud.EndpointOpts{
+		Region: m.OpenStackConfig.Region,
+	})
+	if err != nil {
+		return err
+	}
+
+	// Default master count to 1
+	if m.KubeMasterCount == 0 {
+		m.KubeMasterCount = 1
+	}
+
+	// provision an etcd token
+	url, err := etcdToken(strconv.Itoa(m.KubeMasterCount))
+	if err != nil {
+		return err
+	}
+
+	m.CustomFiles = fmt.Sprintf(`
+  - path: /etc/kubernetes/ssl/cloud.conf
+    permissions: 0600
+    content: |
+      [Global]
+      auth-url = %s
+      username = %s
+      password = %s
+      tenant-id = %s
+      domain-id = %s
+      domain-name = %s
+      region = %s
+      [LoadBalancer]
+      subnet-id = %s`, m.CloudAccount.Credentials["identity_endpoint"],
+		m.CloudAccount.Credentials["username"],
+		m.CloudAccount.Credentials["password"],
+		m.CloudAccount.Credentials["tenant_id"],
+		m.CloudAccount.Credentials["domain_id"],
+		m.CloudAccount.Credentials["domain_name"],
+		m.OpenStackConfig.Region,
+		m.OpenStackConfig.SubnetID,
+	)
+
+	m.KubeProviderString = `
+         --cloud-provider=openstack \
+         --cloud-config=/etc/kubernetes/ssl/cloud.conf \`
+
+	m.ProviderString = `
+          - --cloud-provider=openstack
+          - --cloud-config=/etc/kubernetes/ssl/cloud.conf`
+
+	err = p.Core.DB.Save(m)
+	if err != nil {
+		return err
+	}
+	// save the token
+	m.ETCDDiscoveryURL = url
+
+	// Proceedures
+	// Check for image.
+	procedure.AddStep("Checking that a CoreOS image exists...", func() error {
+		// Create network
+		_, err = images.IDFromName(computeClient, "CoreOS")
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+	// Network
+	procedure.AddStep("Creating Kubernetes Network...", func() error {
+		err := err
+		// Create network
+		net, err := networks.Create(networkClient, networks.CreateOpts{
+			Name:         m.Name + "-network",
+			AdminStateUp: gophercloud.Enabled,
+		}).Extract()
+		if err != nil {
+			return err
+		}
+		// Save result
+		m.OpenStackConfig.NetworkID = net.ID
+		return nil
+	})
+
+	// Subnet
+	procedure.AddStep("Creating Kubernetes Subnet...", func() error {
+		err := err
+		// Create subnet
+		sub, err := subnets.Create(networkClient, subnets.CreateOpts{
+			NetworkID:      m.OpenStackConfig.NetworkID,
+			CIDR:           m.OpenStackConfig.PrivateSubnetRange,
+			IPVersion:      gophercloud.IPv4,
+			Name:           m.Name + "-subnet",
+			DNSNameservers: []string{"8.8.8.8"},
+		}).Extract()
+		if err != nil {
+			return err
+		}
+		// Save result
+		m.OpenStackConfig.SubnetID = sub.ID
+		err = p.Core.DB.Save(m)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+
+	// Network
+	procedure.AddStep("Creating Kubernetes Router...", func() error {
+		err := err
+		// Create Router
+		var opts routers.CreateOpts
+		if m.OpenStackConfig.PublicGatwayID != publicDisabled {
+			opts = routers.CreateOpts{
+				Name:         m.Name + "-router",
+				AdminStateUp: gophercloud.Enabled,
+				GatewayInfo: &routers.GatewayInfo{
+					NetworkID: m.OpenStackConfig.PublicGatwayID,
+				},
+			}
+		} else {
+			opts = routers.CreateOpts{
+				Name:         m.Name + "-router",
+				AdminStateUp: gophercloud.Enabled,
+			}
+		}
+		router, err := routers.Create(networkClient, opts).Extract()
+		if err != nil {
+			return err
+		}
+
+		// interface our subnet to the new router.
+		routers.AddInterface(networkClient, router.ID, routers.AddInterfaceOpts{
+			SubnetID: m.OpenStackConfig.SubnetID,
+		})
+		m.OpenStackConfig.RouterID = router.ID
+		return nil
+	})
+
+	for i := 1; i <= m.KubeMasterCount; i++ {
+		// Create master(s)
+		count := strconv.Itoa(i)
+		// Master
+		procedure.AddStep("Creating Kubernetes Master Node "+count+"...", func() error {
+			err := err
+			// Build template
+
+			// Master name
+			name := m.Name + "-master" + "-" + strings.ToLower(util.RandomString(5))
+
+			m.MasterName = name
+
+			masterUserdataTemplate, err := bindata.Asset("config/providers/common/" + m.KubernetesVersion + "/master.yaml")
+			if err != nil {
+				return err
+			}
+			masterTemplate, err := template.New("master_template").Parse(string(masterUserdataTemplate))
+			if err != nil {
+				return err
+			}
+			var masterUserdata bytes.Buffer
+			if err = masterTemplate.Execute(&masterUserdata, m); err != nil {
+				return err
+			}
+			//fmt.Println(masterUserdata.String())
+			// Create Server
+
+			serverCreateOpts := servers.CreateOpts{
+				ServiceClient: computeClient,
+				Name:          name,
+				FlavorName:    m.MasterNodeSize,
+				ImageName:     m.OpenStackConfig.ImageName,
+				UserData:      masterUserdata.Bytes(),
+				Networks: []servers.Network{
+					servers.Network{UUID: m.OpenStackConfig.NetworkID},
+				},
+				Metadata: map[string]string{"kubernetes-cluster": m.Name, "Role": "master"},
+			}
+			p.Core.Log.Debug(m.OpenStackConfig.ImageName)
+			masterServer, err := servers.Create(computeClient, serverCreateOpts).Extract()
+			if err != nil {
+				return err
+			}
+
+			// Save serverID
+			m.MasterID = masterServer.ID
+			m.MasterNodes = append(m.MasterNodes, masterServer.ID)
+			p.Core.DB.Save(m)
+			// Wait for IP to be assigned.
+			pNetwork := m.Name + "-network"
+			duration := 2 * time.Minute
+			interval := 10 * time.Second
+			waitErr := util.WaitFor("Kubernetes Master IP asssign...", duration, interval, func() (bool, error) {
+				server, _ := servers.Get(computeClient, masterServer.ID).Extract()
+				if server.Addresses[pNetwork] == nil {
+					return false, nil
+				}
+				items := server.Addresses[pNetwork].([]interface{})
+				for _, item := range items {
+					itemMap := item.(map[string]interface{})
+					m.MasterPrivateIP = itemMap["addr"].(string)
+				}
+				return true, nil
+			})
+			if waitErr != nil {
+				return waitErr
+			}
+
+			return nil
+		})
+	}
+
+	// Setup floading IP for master api
+	if m.OpenStackConfig.PublicGatwayID != publicDisabled {
+
+		procedure.AddStep("Waiting for Kubernetes Floating IP to create...", func() error {
+			err := err
+			// Lets keep trying to create
+			var floatIP *floatingips.FloatingIP
+			duration := 5 * time.Minute
+			interval := 10 * time.Second
+			waitErr := util.WaitFor("OpenStack floating IP creation", duration, interval, func() (bool, error) {
+				opts := floatingips.CreateOpts{
+					FloatingNetworkID: m.OpenStackConfig.PublicGatwayID,
+				}
+				floatIP, err = floatingips.Create(networkClient, opts).Extract()
+				if err != nil {
+					if strings.Contains(err.Error(), "Quota exceeded for resources") {
+						// Don't return error, just return false to indicate we should retry.
+						return false, nil
+					}
+					// Else this is another more badder type of error
+					return false, err
+				}
+				return true, nil
+			})
+			if waitErr != nil {
+				return waitErr
+			}
+			// save results
+			m.OpenStackConfig.FloatingIPID = floatIP.ID
+			// Associate with master
+			associateOpts := floatingip.AssociateOpts{
+				FloatingIP: floatIP.FloatingIP,
+			}
+			err = floatingip.AssociateInstance(computeClient, m.MasterID, associateOpts).ExtractErr()
+			if err != nil {
+				return err
+			}
+
+			m.MasterPublicIP = floatIP.FloatingIP
+			return nil
+		})
+	}
+	// Minion
+	procedure.AddStep("Creating Kubernetes Worker Node...", func() error {
+		// Load Nodes to see if we've already created a minion
+		// TODO -- I think we can get rid of a lot of this do-unless behavior if we
+		// modify Procedure to save progess on Action (which is easy to implement).
+		if err := p.Core.DB.Find(&m.Nodes, "kube_name = ?", m.Name); err != nil {
+			return err
+		}
+		if len(m.Nodes) > 0 {
+			return nil
+		}
+
+		node := &model.Node{
+			KubeName: m.Name,
+			Kube:     m,
+			Size:     m.NodeSizes[0],
+		}
+		return p.Core.Nodes.Create(node)
+	})
+
+	procedure.AddStep("waiting for Kubernetes", func() error {
+		return action.CancellableWaitFor("Kubernetes API and first minion", 20*time.Minute, 3*time.Second, func() (bool, error) {
+			k8s := p.Core.K8S(m)
+			k8sNodes, err := k8s.ListNodes("")
+			if err != nil {
+				return false, nil
+			}
+			return len(k8sNodes) > 0, nil
+		})
+	})
+
+	return procedure.Run()
+}

--- a/pkg/provider/openstack/create_node.go
+++ b/pkg/provider/openstack/create_node.go
@@ -1,0 +1,91 @@
+package openstack
+
+import (
+	"bytes"
+	"text/template"
+	"time"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
+	"github.com/supergiant/supergiant/bindata"
+	"github.com/supergiant/supergiant/pkg/core"
+	"github.com/supergiant/supergiant/pkg/model"
+	"github.com/supergiant/supergiant/pkg/util"
+)
+
+// CreateNode creates a new minion on DO kubernetes cluster.
+func (p *Provider) CreateNode(m *model.Node, action *core.Action) error {
+	// fetch an authenticated provider.
+	authenticatedProvider, err := p.Client(m.Kube)
+	if err != nil {
+		return err
+	}
+
+	// Fetch compute client.
+	computeClient, err := openstack.NewComputeV2(authenticatedProvider, gophercloud.EndpointOpts{
+		Region: m.Kube.OpenStackConfig.Region,
+	})
+	if err != nil {
+		return err
+	}
+	m.Name = m.Kube.Name + "-node"
+	// Build template
+	minionUserdataTemplate, err := bindata.Asset("config/providers/common/" + m.Kube.KubernetesVersion + "/minion.yaml")
+	if err != nil {
+		return err
+	}
+	minionTemplate, err := template.New("minion_template").Parse(string(minionUserdataTemplate))
+	if err != nil {
+		return err
+	}
+	var minionUserdata bytes.Buffer
+	if err = minionTemplate.Execute(&minionUserdata, m); err != nil {
+		return err
+	}
+	//fmt.Println(minionUserdata.String())
+	serverCreateOpts := servers.CreateOpts{
+		ServiceClient: computeClient,
+		Name:          m.Name,
+		FlavorName:    m.Size,
+		ImageName:     m.Kube.OpenStackConfig.ImageName,
+		UserData:      minionUserdata.Bytes(),
+		Networks: []servers.Network{
+			servers.Network{UUID: m.Kube.OpenStackConfig.NetworkID},
+		},
+		Metadata: map[string]string{"kubernetes-cluster": m.Kube.Name, "Role": "minion"},
+	}
+
+	// Create server
+	server, err := servers.Create(computeClient, serverCreateOpts).Extract()
+	if err != nil {
+		return err
+	}
+	// Save data
+	m.ProviderID = server.ID
+	m.ProviderCreationTimestamp = time.Now()
+
+	p.Core.DB.Save(m)
+
+	// Wait for IP to be assigned.
+	pNetwork := m.Kube.Name + "-network"
+	duration := 2 * time.Minute
+	interval := 10 * time.Second
+	waitErr := util.WaitFor("Kubernetes Minion IP asssign...", duration, interval, func() (bool, error) {
+		serverObj, _ := servers.Get(computeClient, server.ID).Extract()
+		if serverObj.Addresses[pNetwork] == nil {
+			return false, nil
+		}
+		items := serverObj.Addresses[pNetwork].([]interface{})
+		for _, item := range items {
+			itemMap := item.(map[string]interface{})
+			m.Name = itemMap["addr"].(string)
+		}
+		return true, nil
+	})
+	if waitErr != nil {
+		return waitErr
+	}
+
+	return p.Core.DB.Save(m)
+}

--- a/pkg/provider/openstack/create_node.go
+++ b/pkg/provider/openstack/create_node.go
@@ -14,7 +14,7 @@ import (
 	"github.com/supergiant/supergiant/pkg/util"
 )
 
-// CreateNode creates a new minion on DO kubernetes cluster.
+// CreateNode creates a new node for a kubernetes cluster.
 func (p *Provider) CreateNode(m *model.Node, action *core.Action) error {
 	// fetch an authenticated provider.
 	authenticatedProvider, err := p.Client(m.Kube)
@@ -43,7 +43,6 @@ func (p *Provider) CreateNode(m *model.Node, action *core.Action) error {
 	if err = minionTemplate.Execute(&minionUserdata, m); err != nil {
 		return err
 	}
-	//fmt.Println(minionUserdata.String())
 	serverCreateOpts := servers.CreateOpts{
 		ServiceClient: computeClient,
 		Name:          m.Name,

--- a/pkg/provider/openstack/delete_kube.go
+++ b/pkg/provider/openstack/delete_kube.go
@@ -13,7 +13,7 @@ import (
 	"github.com/supergiant/supergiant/pkg/model"
 )
 
-// DeleteKube deletes a DO kubernetes cluster.
+// DeleteKube deletes a kubernetes cluster.
 func (p *Provider) DeleteKube(m *model.Kube, action *core.Action) error {
 	// Initialize steps
 	procedure := &core.Procedure{

--- a/pkg/provider/openstack/delete_kube.go
+++ b/pkg/provider/openstack/delete_kube.go
@@ -1,0 +1,156 @@
+package openstack
+
+import (
+	"time"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack"
+	floatingip "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/floatingips"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
+	"github.com/supergiant/supergiant/pkg/core"
+	"github.com/supergiant/supergiant/pkg/model"
+)
+
+// DeleteKube deletes a DO kubernetes cluster.
+func (p *Provider) DeleteKube(m *model.Kube, action *core.Action) error {
+	// Initialize steps
+	procedure := &core.Procedure{
+		Core:   p.Core,
+		Name:   "Delete Kube",
+		Model:  m,
+		Action: action,
+	}
+	// fetch an authenticated provider.
+	authenticatedProvider, err := p.Client(m)
+	if err != nil {
+		if ignoreErrors(err) {
+			return nil
+		}
+		return err
+	}
+	// Fetch compute client.
+	computeClient, err := openstack.NewComputeV2(authenticatedProvider, gophercloud.EndpointOpts{
+		Region: m.OpenStackConfig.Region,
+	})
+	if err != nil {
+		if ignoreErrors(err) {
+			return nil
+		}
+		return err
+	}
+
+	// Fetch network client.
+	networkClient, err := openstack.NewNetworkV2(authenticatedProvider, gophercloud.EndpointOpts{
+		Region: m.OpenStackConfig.Region,
+	})
+	if err != nil {
+		if ignoreErrors(err) {
+			return nil
+		}
+		return err
+	}
+
+	if m.OpenStackConfig.PublicGatwayID != publicDisabled {
+		procedure.AddStep("Destroying kubernetes Floating IP...", func() error {
+			err := err
+			floatIP, err := floatingip.Get(computeClient, m.OpenStackConfig.FloatingIPID).Extract()
+			if err != nil {
+				if ignoreErrors(err) {
+					return nil
+				}
+				return err
+			}
+			// Disassociate Instance from floating IP
+			disassociateOpts := floatingip.DisassociateOpts{
+				FloatingIP: floatIP.IP,
+			}
+
+			err = floatingip.DisassociateInstance(computeClient, floatIP.InstanceID, disassociateOpts).ExtractErr()
+			if err != nil {
+				if ignoreErrors(err) {
+					return nil
+				}
+				return err
+			}
+			// Delete the floating IP
+			err = floatingip.Delete(networkClient, floatIP.ID).ExtractErr()
+			if err != nil {
+				if ignoreErrors(err) {
+					return nil
+				}
+				return err
+			}
+			return nil
+		})
+	}
+
+	procedure.AddStep("Destroying kubernetes master nodes...", func() error {
+		err := err
+		for _, node := range m.MasterNodes {
+			err = servers.Delete(computeClient, node).ExtractErr()
+			if err != nil {
+				if ignoreErrors(err) {
+					return nil
+				}
+				return err
+			}
+
+			return action.CancellableWaitFor("Wait for master delete", 20*time.Minute, 3*time.Second, func() (bool, error) {
+				_, err := servers.Get(computeClient, node).Extract()
+				if err == nil {
+					return false, nil
+				}
+				return true, nil
+			})
+
+		}
+		return nil
+	})
+
+	procedure.AddStep("Destroying kubernetes Router...", func() error {
+		// Remove router interface
+		_, err = routers.RemoveInterface(networkClient, m.OpenStackConfig.RouterID, routers.RemoveInterfaceOpts{
+			SubnetID: m.OpenStackConfig.SubnetID,
+		}).Extract()
+		if err != nil {
+			if ignoreErrors(err) {
+				return nil
+			}
+			return err
+		}
+		// Delete router
+		result := routers.Delete(networkClient, m.OpenStackConfig.RouterID)
+		err = result.ExtractErr()
+		if err != nil {
+			if ignoreErrors(err) {
+				return nil
+			}
+			return err
+		}
+
+		return nil
+	})
+
+	procedure.AddStep("Destroying kubernetes network...", func() error {
+		// Delete network
+		err := networks.Delete(networkClient, m.OpenStackConfig.NetworkID).ExtractErr()
+		if err != nil {
+			if ignoreErrors(err) {
+				return nil
+			}
+			return err
+		}
+		return action.CancellableWaitFor("Wait for network delete", 20*time.Minute, 3*time.Second, func() (bool, error) {
+			_, err := networks.Get(computeClient, m.OpenStackConfig.NetworkID).Extract()
+			if err == nil {
+				return false, nil
+			}
+			networks.Delete(networkClient, m.OpenStackConfig.NetworkID).ExtractErr()
+			return true, nil
+		})
+	})
+
+	return procedure.Run()
+}

--- a/pkg/provider/openstack/delete_node.go
+++ b/pkg/provider/openstack/delete_node.go
@@ -10,7 +10,7 @@ import (
 	"github.com/supergiant/supergiant/pkg/model"
 )
 
-// DeleteNode deletes a minsion on a DO kubernetes cluster.
+// DeleteNode deletes a node on a kubernetes cluster.
 func (p *Provider) DeleteNode(m *model.Node, action *core.Action) error {
 	// fetch an authenticated provider.
 	authenticatedProvider, err := p.Client(m.Kube)

--- a/pkg/provider/openstack/delete_node.go
+++ b/pkg/provider/openstack/delete_node.go
@@ -1,0 +1,44 @@
+package openstack
+
+import (
+	"time"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
+	"github.com/supergiant/supergiant/pkg/core"
+	"github.com/supergiant/supergiant/pkg/model"
+)
+
+// DeleteNode deletes a minsion on a DO kubernetes cluster.
+func (p *Provider) DeleteNode(m *model.Node, action *core.Action) error {
+	// fetch an authenticated provider.
+	authenticatedProvider, err := p.Client(m.Kube)
+	if err != nil {
+		return err
+	}
+
+	// Fetch compute client.
+	computeClient, err := openstack.NewComputeV2(authenticatedProvider, gophercloud.EndpointOpts{
+		Region: m.Kube.OpenStackConfig.Region,
+	})
+	if err != nil {
+		return err
+	}
+
+	err = servers.Delete(computeClient, m.ProviderID).ExtractErr()
+	if err != nil {
+		if ignoreErrors(err) {
+			return nil
+		}
+		return err
+	}
+
+	return action.CancellableWaitFor("Wait for node delete", 20*time.Minute, 3*time.Second, func() (bool, error) {
+		_, err := servers.Get(computeClient, m.ProviderID).Extract()
+		if err == nil {
+			return false, nil
+		}
+		return true, nil
+	})
+}

--- a/pkg/provider/openstack/provider.go
+++ b/pkg/provider/openstack/provider.go
@@ -1,23 +1,14 @@
 package openstack
 
 import (
-	"bytes"
+	"io/ioutil"
+	"net/http"
 	"strings"
-	"text/template"
-	"time"
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack"
-	floatingip "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/floatingips"
-	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
-	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/floatingips"
-	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers"
-	"github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
-	"github.com/gophercloud/gophercloud/openstack/networking/v2/subnets"
-	"github.com/supergiant/supergiant/bindata"
 	"github.com/supergiant/supergiant/pkg/core"
 	"github.com/supergiant/supergiant/pkg/model"
-	"github.com/supergiant/supergiant/pkg/util"
 )
 
 // Provider Holds DO account info.
@@ -34,458 +25,6 @@ var (
 func (p *Provider) ValidateAccount(m *model.CloudAccount) error {
 	_, err := p.Client(&model.Kube{CloudAccount: m})
 	if err != nil {
-		return err
-	}
-	return nil
-}
-
-// CreateKube creates a new DO kubernetes cluster.
-func (p *Provider) CreateKube(m *model.Kube, action *core.Action) error {
-
-	// Initialize steps
-	procedure := &core.Procedure{
-		Core:   p.Core,
-		Name:   "Create Kube",
-		Model:  m,
-		Action: action,
-	}
-
-	// Method vars
-	masterName := m.Name + "-master"
-
-	// fetch an authenticated provider.
-	authenticatedProvider, err := p.Client(m)
-	if err != nil {
-		return err
-	}
-
-	// Fetch compute client.
-	computeClient, err := openstack.NewComputeV2(authenticatedProvider, gophercloud.EndpointOpts{
-		Region: m.OpenStackConfig.Region,
-	})
-	if err != nil {
-		return err
-	}
-
-	// Fetch network client.
-	networkClient, err := openstack.NewNetworkV2(authenticatedProvider, gophercloud.EndpointOpts{
-		Region: m.OpenStackConfig.Region,
-	})
-	if err != nil {
-		return err
-	}
-
-	// Proceedures
-	// Network
-	procedure.AddStep("Creating Kubernetes Network...", func() error {
-		err := err
-		// Create network
-		net, err := networks.Create(networkClient, networks.CreateOpts{
-			Name:         m.Name + "-network",
-			AdminStateUp: gophercloud.Enabled,
-		}).Extract()
-		if err != nil {
-			return err
-		}
-		// Save result
-		m.OpenStackConfig.NetworkID = net.ID
-		return nil
-	})
-
-	// Subnet
-	procedure.AddStep("Creating Kubernetes Subnet...", func() error {
-		err := err
-		// Create subnet
-		sub, err := subnets.Create(networkClient, subnets.CreateOpts{
-			NetworkID:      m.OpenStackConfig.NetworkID,
-			CIDR:           m.OpenStackConfig.PrivateSubnetRange,
-			IPVersion:      gophercloud.IPv4,
-			Name:           m.Name + "-subnet",
-			DNSNameservers: []string{"8.8.8.8"},
-		}).Extract()
-		if err != nil {
-			return err
-		}
-		// Save result
-		m.OpenStackConfig.SubnetID = sub.ID
-		return nil
-	})
-
-	// Network
-	procedure.AddStep("Creating Kubernetes Router...", func() error {
-		err := err
-		// Create Router
-		var opts routers.CreateOpts
-		if m.OpenStackConfig.PublicGatwayID != publicDisabled {
-			opts = routers.CreateOpts{
-				Name:         m.Name + "-router",
-				AdminStateUp: gophercloud.Enabled,
-				GatewayInfo: &routers.GatewayInfo{
-					NetworkID: m.OpenStackConfig.PublicGatwayID,
-				},
-			}
-		} else {
-			opts = routers.CreateOpts{
-				Name:         m.Name + "-router",
-				AdminStateUp: gophercloud.Enabled,
-			}
-		}
-		router, err := routers.Create(networkClient, opts).Extract()
-		if err != nil {
-			return err
-		}
-
-		// interface our subnet to the new router.
-		routers.AddInterface(networkClient, router.ID, routers.AddInterfaceOpts{
-			SubnetID: m.OpenStackConfig.SubnetID,
-		})
-		m.OpenStackConfig.RouterID = router.ID
-		return nil
-	})
-
-	// Master
-	procedure.AddStep("Creating Kubernetes Master...", func() error {
-		err := err
-		// Build template
-		masterUserdataTemplate, err := bindata.Asset("config/providers/openstack/master.yaml")
-		if err != nil {
-			return err
-		}
-		masterTemplate, err := template.New("master_template").Parse(string(masterUserdataTemplate))
-		if err != nil {
-			return err
-		}
-		var masterUserdata bytes.Buffer
-		if err = masterTemplate.Execute(&masterUserdata, m); err != nil {
-			return err
-		}
-
-		// Create Server
-		//
-		serverCreateOpts := servers.CreateOpts{
-			ServiceClient: computeClient,
-			Name:          masterName,
-			FlavorName:    m.MasterNodeSize,
-			ImageName:     m.OpenStackConfig.ImageName,
-			UserData:      masterUserdata.Bytes(),
-			Networks: []servers.Network{
-				servers.Network{UUID: m.OpenStackConfig.NetworkID},
-			},
-			Metadata: map[string]string{"kubernetes-cluster": m.Name, "Role": "master"},
-		}
-		p.Core.Log.Debug(m.OpenStackConfig.ImageName)
-		masterServer, err := servers.Create(computeClient, serverCreateOpts).Extract()
-		if err != nil {
-			return err
-		}
-
-		// Save serverID
-		m.OpenStackConfig.MasterID = masterServer.ID
-
-		// Wait for IP to be assigned.
-		pNetwork := m.Name + "-network"
-		duration := 2 * time.Minute
-		interval := 10 * time.Second
-		waitErr := util.WaitFor("Kubernetes Master IP asssign...", duration, interval, func() (bool, error) {
-			server, _ := servers.Get(computeClient, masterServer.ID).Extract()
-			if server.Addresses[pNetwork] == nil {
-				return false, nil
-			}
-			items := server.Addresses[pNetwork].([]interface{})
-			for _, item := range items {
-				itemMap := item.(map[string]interface{})
-				m.OpenStackConfig.MasterPrivateIP = itemMap["addr"].(string)
-			}
-			return true, nil
-		})
-		if waitErr != nil {
-			return waitErr
-		}
-
-		return nil
-	})
-
-	// Setup floading IP for master api
-	if m.OpenStackConfig.PublicGatwayID != publicDisabled {
-
-		procedure.AddStep("Waiting for Kubernetes Floating IP to create...", func() error {
-			err := err
-			// Lets keep trying to create
-			var floatIP *floatingips.FloatingIP
-			duration := 5 * time.Minute
-			interval := 10 * time.Second
-			waitErr := util.WaitFor("OpenStack floating IP creation", duration, interval, func() (bool, error) {
-				opts := floatingips.CreateOpts{
-					FloatingNetworkID: m.OpenStackConfig.PublicGatwayID,
-				}
-				floatIP, err = floatingips.Create(networkClient, opts).Extract()
-				if err != nil {
-					if strings.Contains(err.Error(), "Quota exceeded for resources") {
-						// Don't return error, just return false to indicate we should retry.
-						return false, nil
-					}
-					// Else this is another more badder type of error
-					return false, err
-				}
-				return true, nil
-			})
-			if waitErr != nil {
-				return waitErr
-			}
-			// save results
-			m.OpenStackConfig.FloatingIPID = floatIP.ID
-			// Associate with master
-			associateOpts := floatingip.AssociateOpts{
-				FloatingIP: floatIP.FloatingIP,
-			}
-			err = floatingip.AssociateInstance(computeClient, m.OpenStackConfig.MasterID, associateOpts).ExtractErr()
-			if err != nil {
-				return err
-			}
-
-			m.MasterPublicIP = floatIP.FloatingIP
-			return nil
-		})
-	}
-	// Minion
-	procedure.AddStep("Creating Kubernetes Minion...", func() error {
-		// Load Nodes to see if we've already created a minion
-		// TODO -- I think we can get rid of a lot of this do-unless behavior if we
-		// modify Procedure to save progess on Action (which is easy to implement).
-		if err := p.Core.DB.Find(&m.Nodes, "kube_name = ?", m.Name); err != nil {
-			return err
-		}
-		if len(m.Nodes) > 0 {
-			return nil
-		}
-
-		node := &model.Node{
-			KubeName: m.Name,
-			Kube:     m,
-			Size:     m.NodeSizes[0],
-		}
-		return p.Core.Nodes.Create(node)
-	})
-	return procedure.Run()
-}
-
-// DeleteKube deletes a DO kubernetes cluster.
-func (p *Provider) DeleteKube(m *model.Kube, action *core.Action) error {
-	// Initialize steps
-	procedure := &core.Procedure{
-		Core:   p.Core,
-		Name:   "Delete Kube",
-		Model:  m,
-		Action: action,
-	}
-	// fetch an authenticated provider.
-	authenticatedProvider, err := p.Client(m)
-	if err != nil {
-		return err
-	}
-	// Fetch compute client.
-	computeClient, err := openstack.NewComputeV2(authenticatedProvider, gophercloud.EndpointOpts{
-		Region: m.OpenStackConfig.Region,
-	})
-	if err != nil {
-		return err
-	}
-
-	// Fetch network client.
-	networkClient, err := openstack.NewNetworkV2(authenticatedProvider, gophercloud.EndpointOpts{
-		Region: m.OpenStackConfig.Region,
-	})
-	if err != nil {
-		return err
-	}
-	if m.OpenStackConfig.PublicGatwayID != publicDisabled {
-		procedure.AddStep("Destroying kubernetes Floating IP...", func() error {
-			err := err
-			floatIP, err := floatingip.Get(computeClient, m.OpenStackConfig.FloatingIPID).Extract()
-			if err != nil {
-				if strings.Contains(err.Error(), "404") {
-					// it does not exist,
-					return nil
-				}
-				return err
-			}
-			// Disassociate Instance from floating IP
-			disassociateOpts := floatingip.DisassociateOpts{
-				FloatingIP: floatIP.IP,
-			}
-			err = floatingip.DisassociateInstance(computeClient, floatIP.ID, disassociateOpts).ExtractErr()
-			if err != nil {
-				if strings.Contains(err.Error(), "field missing") {
-					// it does not exist,
-					return nil
-				}
-				return err
-			}
-			// Delete the floating IP
-			err = floatingips.Delete(networkClient, floatIP.ID).ExtractErr()
-			if err != nil {
-				if strings.Contains(err.Error(), "404") {
-					// it does not exist,
-					return nil
-				}
-				return err
-			}
-			return nil
-		})
-	}
-
-	procedure.AddStep("Destroying kubernetes nodes...", func() error {
-		err := err
-		err = servers.Delete(computeClient, m.OpenStackConfig.MasterID).ExtractErr()
-		if err != nil {
-			if strings.Contains(err.Error(), "404") {
-				// it does not exist,
-				return nil
-			}
-			return err
-		}
-		return nil
-	})
-
-	procedure.AddStep("Destroying kubernetes Router...", func() error {
-		// Remove router interface
-		_, err = routers.RemoveInterface(networkClient, m.OpenStackConfig.RouterID, routers.RemoveInterfaceOpts{
-			SubnetID: m.OpenStackConfig.SubnetID,
-		}).Extract()
-		if err != nil {
-			if strings.Contains(err.Error(), "Expected HTTP") {
-				// it does not exist,
-				return nil
-			}
-			return err
-		}
-		// Delete router
-		result := routers.Delete(networkClient, m.OpenStackConfig.RouterID)
-		err = result.ExtractErr()
-		if err != nil {
-			if strings.Contains(err.Error(), "404") {
-				// it does not exist,
-				return nil
-			}
-			return err
-		}
-
-		return nil
-	})
-
-	procedure.AddStep("Destroying kubernetes network...", func() error {
-		// Delete network
-		result := networks.Delete(networkClient, m.OpenStackConfig.NetworkID)
-		err = result.ExtractErr()
-		if err != nil {
-			if strings.Contains(err.Error(), "404") {
-				// it does not exist,
-				return nil
-			}
-			return err
-		}
-		return nil
-	})
-
-	return procedure.Run()
-}
-
-// CreateNode creates a new minion on DO kubernetes cluster.
-func (p *Provider) CreateNode(m *model.Node, action *core.Action) error {
-	// fetch an authenticated provider.
-	authenticatedProvider, err := p.Client(m.Kube)
-	if err != nil {
-		return err
-	}
-
-	// Fetch compute client.
-	computeClient, err := openstack.NewComputeV2(authenticatedProvider, gophercloud.EndpointOpts{
-		Region: m.Kube.OpenStackConfig.Region,
-	})
-	if err != nil {
-		return err
-	}
-	m.Name = m.Kube.Name + "-minion-" + util.RandomString(5)
-	// Build template
-	minionUserdataTemplate, err := bindata.Asset("config/providers/openstack/minion.yaml")
-	if err != nil {
-		return err
-	}
-	minionTemplate, err := template.New("minion_template").Parse(string(minionUserdataTemplate))
-	if err != nil {
-		return err
-	}
-	var minionUserdata bytes.Buffer
-	if err = minionTemplate.Execute(&minionUserdata, m); err != nil {
-		return err
-	}
-
-	serverCreateOpts := servers.CreateOpts{
-		ServiceClient: computeClient,
-		Name:          m.Name,
-		FlavorName:    m.Size,
-		ImageName:     m.Kube.OpenStackConfig.ImageName,
-		UserData:      minionUserdata.Bytes(),
-		Networks: []servers.Network{
-			servers.Network{UUID: m.Kube.OpenStackConfig.NetworkID},
-		},
-		Metadata: map[string]string{"kubernetes-cluster": m.Kube.Name, "Role": "minion"},
-	}
-
-	// Create server
-	server, err := servers.Create(computeClient, serverCreateOpts).Extract()
-	if err != nil {
-		return err
-	}
-	// Save data
-	m.ProviderID = server.Name
-	m.ProviderCreationTimestamp = time.Now()
-
-	// Wait for IP to be assigned.
-	pNetwork := m.Kube.Name + "-network"
-	duration := 2 * time.Minute
-	interval := 10 * time.Second
-	waitErr := util.WaitFor("Kubernetes Minion IP asssign...", duration, interval, func() (bool, error) {
-		serverObj, _ := servers.Get(computeClient, server.ID).Extract()
-		if serverObj.Addresses[pNetwork] == nil {
-			return false, nil
-		}
-		items := serverObj.Addresses[pNetwork].([]interface{})
-		for _, item := range items {
-			itemMap := item.(map[string]interface{})
-			m.Name = itemMap["addr"].(string)
-		}
-		return true, nil
-	})
-	if waitErr != nil {
-		return waitErr
-	}
-
-	return p.Core.DB.Save(m)
-}
-
-// DeleteNode deletes a minsion on a DO kubernetes cluster.
-func (p *Provider) DeleteNode(m *model.Node, action *core.Action) error {
-	// fetch an authenticated provider.
-	authenticatedProvider, err := p.Client(m.Kube)
-	if err != nil {
-		return err
-	}
-
-	// Fetch compute client.
-	computeClient, err := openstack.NewComputeV2(authenticatedProvider, gophercloud.EndpointOpts{
-		Region: m.Kube.OpenStackConfig.Region,
-	})
-	if err != nil {
-		return err
-	}
-
-	err = servers.Delete(computeClient, m.ProviderID).ExtractErr()
-	if err != nil {
-		if strings.Contains(err.Error(), "404") {
-			// it does not exist,
-			return nil
-		}
 		return err
 	}
 	return nil
@@ -524,4 +63,37 @@ func Client(kube *model.Kube) (*gophercloud.ProviderClient, error) {
 	}
 
 	return client, nil
+}
+
+func ignoreErrors(err error) bool {
+	okErrors := []string{
+		"No suitable endpoint",
+		"i/o timeout",
+		"404",
+		"host is down",
+		"is not associated with instance",
+		"Resource not found",
+		"At least one of SubnetID and PortID must be provided",
+	}
+
+	for _, msg := range okErrors {
+		if strings.Contains(err.Error(), msg) {
+			return true
+		}
+	}
+	return false
+}
+
+func etcdToken(num string) (string, error) {
+	resp, err := http.Get("https://discovery.etcd.io/new?size=" + num + "")
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	return string(body), nil
 }

--- a/pkg/ui/kubes_controller.go
+++ b/pkg/ui/kubes_controller.go
@@ -41,6 +41,7 @@ func NewKube(sg *client.Client, w http.ResponseWriter, r *http.Request) error {
 		m = map[string]interface{}{
 			"cloud_account_name": "",
 			"name":               "",
+			"ssh_pub_key":        "",
 			"master_node_size":   "m1.smaller",
 			"node_sizes": []string{
 				"m1.smaller",
@@ -50,7 +51,6 @@ func NewKube(sg *client.Client, w http.ResponseWriter, r *http.Request) error {
 				"image_name":          "CoreOS",
 				"region":              "RegionOne",
 				"ssh_key_fingerprint": "",
-				"ssh_pub_key":         "",
 			},
 		}
 	case "gce":


### PR DESCRIPTION
This change updates the openstack provider with multi-master
settings, includes issue fixes for #164. This change also uses
a new template scheme that bases templates off kubernetes version
and not provider. This allows us to have certified kubernetes versions.

NOTE:
In the new unified template scheme, the following options have been moved
out of the provider config and up to the root kube config.

- kube_master_count
- ssh_pub_key

Other objects have been moved but they are readonly.

i.e.
```
 {
   "cloud_account_name": "openstack",
   "master_node_size": "m1.small",
   "name": "cheese",
   "node_sizes": [
     "m1.small"
   ],
   "openstack_config": {
     "image_name": "CoreOS",
     "region": "myregion",
     "public_gateway_id": "mygateway"
   },
  "ssh_pub_key": "mypubsshkey"
 }
```