### PR TITLE
AWS Safe VPC injection update.

### DIFF
--- a/pkg/model/kube.go
+++ b/pkg/model/kube.go
@@ -92,8 +92,8 @@ type AWSKubeConfig struct {
 	PrivateKey                    string   `json:"private_key,omitempty" sg:"readonly"`
 	VPCID                         string   `json:"vpc_id"`
 	VPCMANAGED                    bool     `json:"vpc_managed"`
-	InternetGatewayID             string   `json:"internet_gateway_id" sg:"readonly"`
-	RouteTableID                  string   `json:"route_table_id" sg:"readonly"`
+	InternetGatewayID             string   `json:"internet_gateway_id"`
+	RouteTableID                  string   `json:"route_table_id"`
 	RouteTableSubnetAssociationID []string `json:"route_table_subnet_association_id" sg:"readonly"`
 	ELBSecurityGroupID            string   `json:"elb_security_group_id" sg:"readonly"`
 	NodeSecurityGroupID           string   `json:"node_security_group_id" sg:"readonly"`

--- a/pkg/provider/aws/delete_kube.go
+++ b/pkg/provider/aws/delete_kube.go
@@ -113,12 +113,10 @@ func (p *Provider) DeleteKube(m *model.Kube, action *core.Action) error {
 	})
 
 	procedure.AddStep("deleting Internet Gateway", func() error {
-		if m.AWSConfig.InternetGatewayID == "" {
+		if m.AWSConfig.InternetGatewayID == "" || m.AWSConfig.VPCMANAGED == true {
 			return nil
 		}
-		if m.AWSConfig.VPCMANAGED == true {
-			return nil
-		}
+
 		diginput := &ec2.DetachInternetGatewayInput{
 			InternetGatewayId: aws.String(m.AWSConfig.InternetGatewayID),
 			VpcId:             aws.String(m.AWSConfig.VPCID),
@@ -171,10 +169,7 @@ func (p *Provider) DeleteKube(m *model.Kube, action *core.Action) error {
 	})
 
 	procedure.AddStep("deleting public Subnet(s)", func() error {
-		if len(m.AWSConfig.PublicSubnetIPRange) == 0 {
-			return nil
-		}
-		if m.AWSConfig.VPCMANAGED == true {
+		if len(m.AWSConfig.PublicSubnetIPRange) == 0 || m.AWSConfig.VPCMANAGED == true {
 			return nil
 		}
 


### PR DESCRIPTION
This feature is still considered a use at your own risk feature.
This update corrects issues related to injecting a kubernetes cluster
into an existing VPC.

To perform an inhection the user must provide all relevent IDs in
the kube config object.

Example:
```
{
  "aws_config": {
    "region": "us-east-1",
    "vpc_ip_range": "172.16.0.0/16",
    "vpc_id": "vpc-xxxxxxx",
    "internet_gateway_id": "igw-xxxxxx",
    "route_table_id": "rtb-xxxxx",
            "public_subnet_ip_range": [
            {
                "ip_range": "172.16.2.0/24",
                "subnet_id": "subnet-xxxxxx",
                "zone": "us-east-1b"
            }
        ]
  },
  "cloud_account_name": "foo",
  "master_node_size": "m4.large",
  "name": "bar",
  "node_sizes": [
    "m4.large",
    "m4.xlarge",
    "m4.2xlarge",
    "m4.4xlarge"
  ]
}
```