### PR TITLE
DO SSH fingerpring change.

### DIFF
--- a/pkg/ui/kubes_controller.go
+++ b/pkg/ui/kubes_controller.go
@@ -34,7 +34,7 @@ func NewKube(sg *client.Client, w http.ResponseWriter, r *http.Request) error {
 			},
 			"digitalocean_config": map[string]interface{}{
 				"region":              "nyc1",
-				"ssh_key_fingerprint": []string{""},
+				"ssh_key_fingerprint": []string{},
 			},
 		}
 	case "openstack":


### PR DESCRIPTION
This is a slight change to the DO UI template.
The DO api requires the fingerprint option now. The
template has been changed to require the fingerprint.
i.e. You must provide a fingerprint for DO kubes.
Fixes #236 
example:

```
"ssh_key_fingerprint": ["xx:xx:xx:xx:xx", "xx:xx:xx:xx:xx"]
```