### PR TITLE
Small update to AWS subnet public DNS during VPC injection.

### DIFF
--- a/pkg/provider/aws/create_kube.go
+++ b/pkg/provider/aws/create_kube.go
@@ -476,7 +476,9 @@ func (p *Provider) CreateKube(m *model.Kube, action *core.Action) error {
 	})
 
 	procedure.AddStep("enabling public IP assignment setting of Subnet", func() error {
-
+		if m.AWSConfig.VPCMANAGED == true {
+			return nil
+		}
 		for _, subnet := range m.AWSConfig.PublicSubnetIPRange {
 			if subnet["subnet_id"] != "" {
 				_, err := ec2S.ModifySubnetAttribute(&ec2.ModifySubnetAttributeInput{


### PR DESCRIPTION
If your kubernetes cluster is accessable by the outside, you must manually enable
public DNS before build time.

If it is not accessable, you must be sure to have it disabled.

SG will get confused and not know when IP to hit during operation if this
is not manaully set.