### PR TITLE
Update to the Travis build rules.

### DIFF
--- a/build/travis_build.sh
+++ b/build/travis_build.sh
@@ -7,10 +7,40 @@ TAG=${TRAVIS_BRANCH:-unstable}
 
 echo "Tag Name: ${TAG}"
 if [[ "$TAG" =~ ^v[0-100]. ]]; then
-  echo "global deploy"
+  echo "release"
+
+  docker login -u $DOCKER_USER -p $DOCKER_PASS
+
+  ## UI Docker Build
+  REPO=supergiant/supergiant-ui
+  cp dist/supergiant-ui-linux-amd64 build/docker/ui/linux-amd64/
+  cp dist/supergiant-ui-darwin-10.6-amd64 build/docker/ui/darwin-amd64/
+  cp dist/supergiant-ui-windows-4.0-amd64.exe build/docker/ui/windows-amd64/
+  cp dist/supergiant-ui-linux-arm64 build/docker/ui/linux-arm64/
+  docker build -t $REPO:$TAG-linux-x64 -t $REPO:latest  build/docker/ui/linux-amd64/
+  docker build -t $REPO:$TAG-darwin-x64 build/docker/ui/linux-amd64/
+  docker build -t $REPO:$TAG-windows-x64 build/docker/ui/linux-amd64/
+  docker build -t $REPO:$TAG-linux-arm64 build/docker/ui/linux-arm64/
+  docker push $REPO
+
+  ## API Docker Build
+  REPO=supergiant/supergiant-api
+  cp dist/supergiant-server-linux-amd64 build/docker/api/linux-amd64/
+  cp dist/supergiant-server-darwin-10.6-amd64 build/docker/api/darwin-amd64/
+  cp dist/supergiant-server-windows-4.0-amd64.exe build/docker/api/windows-amd64/
+  cp dist/supergiant-server-linux-arm64 build/docker/api/linux-arm64/
+  docker build -t $REPO:$TAG-linux-x64 -t $REPO:latest build/docker/api/linux-amd64/
+  docker build -t $REPO:$TAG-darwin-x64 build/docker/api/linux-amd64/
+  docker build -t $REPO:$TAG-windows-x64 build/docker/api/linux-amd64/
+  docker build -t $REPO:$TAG-linux-arm64 build/docker/api/linux-arm64/
+  docker push $REPO
+
+
   ./packer build build/build_release.json
+elif [[ "$TAG" == "master" ]]; then
+    echo "master *Only Test*"
 else
-  echo "private unstable"
+  echo "branch unstable"
   docker login -u $DOCKER_USER -p $DOCKER_PASS
 
   ## UI Docker Build
@@ -37,6 +67,6 @@ else
   docker build -t $REPO:$TAG-linux-arm64 build/docker/api/linux-arm64/
   docker push $REPO
 
-  echo "private unstable"
-  ./packer build build/build_branch.json
+  ## Maybe a flag to build a test AMI? Just takes a long time...
+  # ./packer build build/build_branch.json
 fi


### PR DESCRIPTION
This change is in support of our new branch method. Docker builds and releases will no longer be triggered on master. Only tests. Releases will occur from version branches. 