### PR TITLE
Support custom tags and roles at the kube level and below.

### DIFF
--- a/pkg/model/kube.go
+++ b/pkg/model/kube.go
@@ -91,19 +91,22 @@ type AWSKubeConfig struct {
 	NodeVolumeSize      int                 `json:"node_volume_size" sg:"default=100"`
 	MasterVolumeSize    int                 `json:"master_volume_size" sg:"default=100"`
 
-	LastSelectedAZ                string   `json:"last_selected_az" sg:"readonly"` // if using multiAZ this is the last az the node build used.
-	PrivateKey                    string   `json:"private_key,omitempty" sg:"readonly"`
-	VPCID                         string   `json:"vpc_id"`
-	VPCMANAGED                    bool     `json:"vpc_managed"`
-	InternetGatewayID             string   `json:"internet_gateway_id"`
-	RouteTableID                  string   `json:"route_table_id"`
-	RouteTableSubnetAssociationID []string `json:"route_table_subnet_association_id" sg:"readonly"`
-	PrivateNetwork                bool     `json:"private_network"`
-	ELBSecurityGroupID            string   `json:"elb_security_group_id" sg:"readonly"`
-	NodeSecurityGroupID           string   `json:"node_security_group_id" sg:"readonly"`
-	ElasticFileSystemID           string   `json:"elastic_filesystem_id"`
-	ElasticFileSystemTargets      []string `json:"elastic_filesystem_targets" sg:"readonly"`
-	BuildElasticFileSystem        bool     `json:"build_elastic_filesystem"`
+	MasterRoleName                string            `json:"master_role"`
+	NodeRoleName                  string            `json:"node_role"`
+	Tags                          map[string]string `json:"tags"`
+	LastSelectedAZ                string            `json:"last_selected_az" sg:"readonly"` // if using multiAZ this is the last az the node build used.
+	PrivateKey                    string            `json:"private_key,omitempty" sg:"readonly"`
+	VPCID                         string            `json:"vpc_id"`
+	VPCMANAGED                    bool              `json:"vpc_managed"`
+	InternetGatewayID             string            `json:"internet_gateway_id"`
+	RouteTableID                  string            `json:"route_table_id"`
+	RouteTableSubnetAssociationID []string          `json:"route_table_subnet_association_id" sg:"readonly"`
+	PrivateNetwork                bool              `json:"private_network"`
+	ELBSecurityGroupID            string            `json:"elb_security_group_id" sg:"readonly"`
+	NodeSecurityGroupID           string            `json:"node_security_group_id" sg:"readonly"`
+	ElasticFileSystemID           string            `json:"elastic_filesystem_id"`
+	ElasticFileSystemTargets      []string          `json:"elastic_filesystem_targets" sg:"readonly"`
+	BuildElasticFileSystem        bool              `json:"build_elastic_filesystem"`
 }
 
 // DOKubeConfig holds do specific information about DO based KUbernetes clusters.

--- a/pkg/provider/aws/provider.go
+++ b/pkg/provider/aws/provider.go
@@ -218,8 +218,13 @@ func createIAMInstanceProfile(iamS iamiface.IAMAPI, name string) error {
 	return nil
 }
 
-func tagAWSResource(ec2S ec2iface.EC2API, idstr string, tags map[string]string) error {
+func tagAWSResource(ec2S ec2iface.EC2API, idstr string, tags map[string]string, confTags map[string]string) error {
 	var ec2Tags []*ec2.Tag
+	if len(confTags) != 0 {
+		for key, val := range confTags {
+			tags[key] = val
+		}
+	}
 	for key, val := range tags {
 		ec2Tags = append(ec2Tags, &ec2.Tag{
 			Key:   aws.String(key),


### PR DESCRIPTION
Added the ability to specify an IAM role for master and node instances on AWS.

under the aws_config for kube you can now set the following:

aws_config {
  master_role: role_name,
  node_role: role_name
}

Also added the ability to set tags at the kube level that will tag any resources made for that kube.
It doesn't tag the S3 bucket (not sure if that is needed/wanted as it stores a single file)
This can be used with the following:

aws_config {
  tags: {tag_name: tag_value,
         another_tag: another_value}
}

No error checking is done on the tag for validity until it is applied, that is left to the user.