### PR TITLE
Fixing App Deletion

### DIFF
--- a/cmd/ui/assets/src/app/apps/apps-list/apps-list.component.html
+++ b/cmd/ui/assets/src/app/apps/apps-list/apps-list.component.html
@@ -12,7 +12,7 @@
 
       <div class="context-secondary-panel">
         <button type="button" class="btn btn-primary" [routerLink]="['/apps/new']">Deploy New App</button>
-        <button [disabled]="selected.length === 0" type="button" class="btn btn-primary" (click)="deleteKube()">Delete Selected App</button>
+        <button [disabled]="selected.length === 0" type="button" class="btn btn-primary" (click)="deleteApp()">Delete Selected App</button>
       </div>
     </div>
 


### PR DESCRIPTION
Fixes #416

This change replaces the function called by the "Delete Selected
App" button from the deleteKube function to deleteApp, which was
already implemented. Reference in issue #416 submitted by @fastjames.