### PR TITLE
Fixing DigitalOcean SSH Key Submission on "Create a Cluster"

### DIFF
--- a/cmd/ui/assets/src/app/apps/apps-list/apps-list.component.html
+++ b/cmd/ui/assets/src/app/apps/apps-list/apps-list.component.html
@@ -12,7 +12,7 @@
 
       <div class="context-secondary-panel">
         <button type="button" class="btn btn-primary" [routerLink]="['/apps/new']">Deploy New App</button>
-        <button [disabled]="selected.length === 0" type="button" class="btn btn-primary" (click)="deleteKube()">Delete Selected App</button>
+        <button [disabled]="selected.length === 0" type="button" class="btn btn-primary" (click)="deleteApp()">Delete Selected App</button>
       </div>
     </div>
 

--- a/cmd/ui/assets/src/app/clusters/cluster.digitalocean.model.ts
+++ b/cmd/ui/assets/src/app/clusters/cluster.digitalocean.model.ts
@@ -33,10 +33,15 @@ export class ClusterDigitalOceanModel {
               'description': 'Region',
               'type': 'string'
             },
-            'ssh_key_fingerprint': {
-              'description': 'SSH Key Fingerprint',
-              'type': 'string'
-            }
+           'ssh_key_fingerprint': {
+             'description': 'SSH Key Fingerprint',
+             'id': '/properties/ssh_key_fingerprint',
+             'items': {
+               'id': '/properties/ssh_key_fingerprint/items',
+               'type': 'string'
+             },
+             'type': 'array'
+           }
           },
           'type': 'object'
         },

--- a/docs/v0/kube.md
+++ b/docs/v0/kube.md
@@ -46,7 +46,7 @@ _Note the node_sizes field corresponds to what server sizes the
   ],
   "digitalocean_config": {
     "region": "nyc1",
-    "ssh_key_fingerprint": "<your_do_ssh_key_fingerprint>"
+    "ssh_key_fingerprint": ["<your_do_ssh_key_fingerprint>","etc"]
   }
 }
 ```


### PR DESCRIPTION
Fixes #418

This change adjusts the field in the schema used by the front end
from a string to an array, allowing the user to submit SSH key
fingerprints in a way that successfully adheres to the DigitalOcean
GoDo Go API client's expectations. Referenced in isse #418 by
@TheKLARKEN.