### PR TITLE
Added scrollbar to overflow content in cloud accounts pages.

### DIFF
--- a/cmd/ui/assets/src/app/system/cloud-accounts/new-cloud-account/new-cloud-account.component.scss
+++ b/cmd/ui/assets/src/app/system/cloud-accounts/new-cloud-account/new-cloud-account.component.scss
@@ -1,0 +1,3 @@
+.app-body {
+   overflow: auto;
+}


### PR DESCRIPTION
Fixes issue #421. A simple css style was added to the app body to allow viewing of the extra content of cloud account pages, so that users can scroll down to fill out the rest of the form instead of zooming out, as referenced by @manigandham.