### PR TITLE
Travis CI ARCH Breakout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ config/config.json
 /build/docker/ui/darwin-amd64/supergiant-ui-darwin-10.6-amd64
 /build/docker/ui/windows-amd64/supergiant-ui-windows-4.0-amd64.exe
 /build/docker/ui/linux-arm64/supergiant-ui-linux-arm64
-/build/docker/api/linux-amd64/supergiant-server-linux-amd64
-/build/docker/api/darwin-amd64/supergiant-server-darwin-10.6-amd64
-/build/docker/api/windows-amd64/supergiant-server-windows-4.0-amd64.exe
-/build/docker/api/linux-arm64/supergiant-server-linux-arm64
+/build/docker/api/linux-amd64/supergiant-api-linux-amd64
+/build/docker/api/darwin-amd64/supergiant-api-darwin-10.6-amd64
+/build/docker/api/windows-amd64/supergiant-api-windows-4.0-amd64.exe
+/build/docker/api/linux-arm64/supergiant-api-linux-arm64

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,11 @@ go_import_path: github.com/supergiant/supergiant
 before_install:
   - sudo apt-get update
   - sudo apt-get install docker-ce
-  - echo 'DOCKER_OPTS="--experimental=true"' | sudo tee --append /etc/default/docker
+  - echo '{"experimental":true}' | sudo tee /etc/docker/daemon.json
+  - mkdir ~/.docker
+  - echo '{"experimental":"enabled"}' | tee ~/.docker/config.json
   - sudo service docker restart
+  - docker version
 
 install:
   - wget https://releases.hashicorp.com/packer/1.0.0/packer_1.0.0_linux_amd64.zip
@@ -57,8 +60,8 @@ script:
   - goveralls -coverprofile=.coverprofile -service=travis-ci
 
   # Cross compile
-  - CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -a -o dist/supergiant-server-linux-arm64 -ldflags '-extldflags "-static"' ./cmd/server
-  - CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o dist/supergiant-server-linux-amd64 -ldflags '-extldflags "-static"' ./cmd/server
+  - CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -a -o dist/supergiant-api-linux-arm64 -ldflags '-extldflags "-static"' ./cmd/server
+  - CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o dist/supergiant-api-linux-amd64 -ldflags '-extldflags "-static"' ./cmd/server
   - CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -a -o dist/supergiant-ui-linux-arm64 -ldflags '-extldflags "-static"' ./cmd/ui
   - CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o dist/supergiant-ui-linux-amd64 -ldflags '-extldflags "-static"' ./cmd/ui
 

--- a/build/docker/api/linux-amd64/Dockerfile
+++ b/build/docker/api/linux-amd64/Dockerfile
@@ -14,6 +14,6 @@ RUN apk add --update curl && \
   rm -rf glibc.apk glibc-bin.apk /var/cache/apk/*
 
 RUN apk add --no-cache ca-certificates
-ADD ./supergiant-server-linux-amd64 /supergiant-api
+ADD ./supergiant-api-linux-amd64 /supergiant-api
 ADD ./config.json /
 CMD ["/supergiant-api"]

--- a/build/docker/api/linux-arm64/Dockerfile
+++ b/build/docker/api/linux-arm64/Dockerfile
@@ -1,5 +1,5 @@
 from alpine
 RUN apk add --no-cache ca-certificates
-ADD ./supergiant-server-linux-arm64 /supergiant-api
+ADD ./supergiant-api-linux-arm64 /supergiant-api
 ADD ./config.json /
 CMD ["/supergiant-api"]


### PR DESCRIPTION
This change will breakout all ARCH builds into
their own dockerhub repo, with the main repo working
as a repository of manifests.