### PR TITLE
[OpenStack] Checks correct image exists in OpenStack

### DIFF
--- a/pkg/provider/openstack/create_kube.go
+++ b/pkg/provider/openstack/create_kube.go
@@ -107,8 +107,8 @@ func (p *Provider) CreateKube(m *model.Kube, action *core.Action) error {
 
 	// Procedures
 	// Check for image.
-	procedure.AddStep("Checking that a CoreOS image exists...", func() error {
-		_, err = images.IDFromName(computeClient, "CoreOS")
+	procedure.AddStep(fmt.Sprintf("Checking that the \"%s\" image exists...", m.OpenStackConfig.ImageName), func() error {
+		_, err = images.IDFromName(computeClient, m.OpenStackConfig.ImageName)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Changes OS provider to check that the image to be used exists, opposed to always checking for an image named "CoreOS" (fixes #440).