### PR TITLE
[OpenStack] SSH key support with OpenStack provider  

### DIFF
--- a/pkg/model/kube.go
+++ b/pkg/model/kube.go
@@ -129,6 +129,7 @@ type OSKubeConfig struct {
 	RouterID     string `json:"router_id" sg:"readonly"`
 	FloatingIPID string `json:"floating_ip_id" sg:"readonly"`
 	ImageName    string `json:"image_name" validate:"nonzero"`
+	KeyPair      string `json:"key_pair" validate:"nonzero" sg:"readonly"`
 }
 
 // GCEKubeConfig holds do specific information about DO based KUbernetes clusters.

--- a/pkg/model/kube.go
+++ b/pkg/model/kube.go
@@ -129,7 +129,8 @@ type OSKubeConfig struct {
 	RouterID     string `json:"router_id" sg:"readonly"`
 	FloatingIPID string `json:"floating_ip_id" sg:"readonly"`
 	ImageName    string `json:"image_name" validate:"nonzero"`
-	KeyPair      string `json:"key_pair" validate:"nonzero" sg:"readonly"`
+	KeyPair      string `json:"key_pair" sg:"readonly"`
+	SSHPubKey    string `json:"ssh_pub_key" validate:"nonzero"`
 }
 
 // GCEKubeConfig holds do specific information about DO based KUbernetes clusters.

--- a/pkg/provider/openstack/create_kube.go
+++ b/pkg/provider/openstack/create_kube.go
@@ -120,8 +120,8 @@ func (p *Provider) CreateKube(m *model.Kube, action *core.Action) error {
 	procedure.AddStep("Creating key pair...", func() error {
 		err := err
 		keypair, err := keypairs.Create(computeClient, keypairs.CreateOpts{
-			Name:      fmt.Sprintf("%-key", m.Name),
-			PublicKey: m.SSHPubKey,
+			Name:      fmt.Sprintf("%s-key", m.Name),
+			PublicKey: m.OpenStackConfig.SSHPubKey,
 		}).Extract()
 		if err != nil {
 			return err
@@ -240,7 +240,7 @@ func (p *Provider) CreateKube(m *model.Kube, action *core.Action) error {
 				},
 				Metadata: map[string]string{"kubernetes-cluster": m.Name, "Role": "master"},
 			}
-			createOpts := keypairs.CreateOpts{
+			createOpts := keypairs.CreateOptsExt{
 				CreateOptsBuilder: serverCreateOpts,
 				KeyName:           m.OpenStackConfig.KeyPair,
 			}

--- a/pkg/provider/openstack/create_node.go
+++ b/pkg/provider/openstack/create_node.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/keypairs"
 	"github.com/supergiant/supergiant/bindata"
 	"github.com/supergiant/supergiant/pkg/core"
 	"github.com/supergiant/supergiant/pkg/model"
@@ -56,9 +57,13 @@ func (p *Provider) CreateNode(m *model.Node, action *core.Action) error {
 		},
 		Metadata: map[string]string{"kubernetes-cluster": m.Kube.Name, "Role": "minion"},
 	}
+	createOpts := keypairs.CreateOptsExt{
+		CreateOptsBuilder: serverCreateOpts,
+		KeyName:           m.Kube.OpenStackConfig.KeyPair,
+	}
 
 	// Create server
-	server, err := servers.Create(computeClient, serverCreateOpts).Extract()
+	server, err := servers.Create(computeClient, createOpts).Extract()
 	if err != nil {
 		return err
 	}

--- a/pkg/provider/openstack/delete_kube.go
+++ b/pkg/provider/openstack/delete_kube.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack"
 	floatingip "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/floatingips"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/keypairs"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
@@ -105,6 +106,18 @@ func (p *Provider) DeleteKube(m *model.Kube, action *core.Action) error {
 				return true, nil
 			})
 
+		}
+		return nil
+	})
+
+	procedure.AddStep("Destroying keypair...", func() error {
+		err := err
+		err = keypairs.Delete(computeClient, m.OpenStackConfig.KeyPair).ExtractErr()
+		if err != nil {
+			if ignoreErrors(err) {
+				return nil
+			}
+			return err
 		}
 		return nil
 	})

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/keypairs/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/keypairs/doc.go
@@ -1,0 +1,71 @@
+/*
+Package keypairs provides the ability to manage key pairs as well as create
+servers with a specified key pair.
+
+Example to List Key Pairs
+
+	allPages, err := keypairs.List(computeClient).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allKeyPairs, err := keypairs.ExtractKeyPairs(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, kp := range allKeyPairs {
+		fmt.Printf("%+v\n", kp)
+	}
+
+Example to Create a Key Pair
+
+	createOpts := keypairs.CreateOpts{
+		Name: "keypair-name",
+	}
+
+	keypair, err := keypairs.Create(computeClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%+v", keypair)
+
+Example to Import a Key Pair
+
+	createOpts := keypairs.CreateOpts{
+		Name:      "keypair-name",
+		PublicKey: "public-key",
+	}
+
+	keypair, err := keypairs.Create(computeClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Delete a Key Pair
+
+	err := keypairs.Delete(computeClient, "keypair-name").ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Create a Server With a Key Pair
+
+	serverCreateOpts := servers.CreateOpts{
+		Name:      "server_name",
+		ImageRef:  "image-uuid",
+		FlavorRef: "flavor-uuid",
+	}
+
+	createOpts := keypairs.CreateOpts{
+		CreateOptsBuilder: serverCreateOpts,
+		KeyName:           "keypair-name",
+	}
+
+	server, err := servers.Create(computeClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+*/
+package keypairs

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/keypairs/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/keypairs/requests.go
@@ -1,0 +1,86 @@
+package keypairs
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// CreateOptsExt adds a KeyPair option to the base CreateOpts.
+type CreateOptsExt struct {
+	servers.CreateOptsBuilder
+
+	// KeyName is the name of the key pair.
+	KeyName string `json:"key_name,omitempty"`
+}
+
+// ToServerCreateMap adds the key_name to the base server creation options.
+func (opts CreateOptsExt) ToServerCreateMap() (map[string]interface{}, error) {
+	base, err := opts.CreateOptsBuilder.ToServerCreateMap()
+	if err != nil {
+		return nil, err
+	}
+
+	if opts.KeyName == "" {
+		return base, nil
+	}
+
+	serverMap := base["server"].(map[string]interface{})
+	serverMap["key_name"] = opts.KeyName
+
+	return base, nil
+}
+
+// List returns a Pager that allows you to iterate over a collection of KeyPairs.
+func List(client *gophercloud.ServiceClient) pagination.Pager {
+	return pagination.NewPager(client, listURL(client), func(r pagination.PageResult) pagination.Page {
+		return KeyPairPage{pagination.SinglePageBase(r)}
+	})
+}
+
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
+type CreateOptsBuilder interface {
+	ToKeyPairCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts specifies KeyPair creation or import parameters.
+type CreateOpts struct {
+	// Name is a friendly name to refer to this KeyPair in other services.
+	Name string `json:"name" required:"true"`
+
+	// PublicKey [optional] is a pregenerated OpenSSH-formatted public key.
+	// If provided, this key will be imported and no new key will be created.
+	PublicKey string `json:"public_key,omitempty"`
+}
+
+// ToKeyPairCreateMap constructs a request body from CreateOpts.
+func (opts CreateOpts) ToKeyPairCreateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "keypair")
+}
+
+// Create requests the creation of a new KeyPair on the server, or to import a
+// pre-existing keypair.
+func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToKeyPairCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(createURL(client), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// Get returns public data about a previously uploaded KeyPair.
+func Get(client *gophercloud.ServiceClient, name string) (r GetResult) {
+	_, r.Err = client.Get(getURL(client, name), &r.Body, nil)
+	return
+}
+
+// Delete requests the deletion of a previous stored KeyPair from the server.
+func Delete(client *gophercloud.ServiceClient, name string) (r DeleteResult) {
+	_, r.Err = client.Delete(deleteURL(client, name), nil)
+	return
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/keypairs/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/keypairs/results.go
@@ -1,0 +1,91 @@
+package keypairs
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// KeyPair is an SSH key known to the OpenStack Cloud that is available to be
+// injected into servers.
+type KeyPair struct {
+	// Name is used to refer to this keypair from other services within this
+	// region.
+	Name string `json:"name"`
+
+	// Fingerprint is a short sequence of bytes that can be used to authenticate
+	// or validate a longer public key.
+	Fingerprint string `json:"fingerprint"`
+
+	// PublicKey is the public key from this pair, in OpenSSH format.
+	// "ssh-rsa AAAAB3Nz..."
+	PublicKey string `json:"public_key"`
+
+	// PrivateKey is the private key from this pair, in PEM format.
+	// "-----BEGIN RSA PRIVATE KEY-----\nMIICXA..."
+	// It is only present if this KeyPair was just returned from a Create call.
+	PrivateKey string `json:"private_key"`
+
+	// UserID is the user who owns this KeyPair.
+	UserID string `json:"user_id"`
+}
+
+// KeyPairPage stores a single page of all KeyPair results from a List call.
+// Use the ExtractKeyPairs function to convert the results to a slice of
+// KeyPairs.
+type KeyPairPage struct {
+	pagination.SinglePageBase
+}
+
+// IsEmpty determines whether or not a KeyPairPage is empty.
+func (page KeyPairPage) IsEmpty() (bool, error) {
+	ks, err := ExtractKeyPairs(page)
+	return len(ks) == 0, err
+}
+
+// ExtractKeyPairs interprets a page of results as a slice of KeyPairs.
+func ExtractKeyPairs(r pagination.Page) ([]KeyPair, error) {
+	type pair struct {
+		KeyPair KeyPair `json:"keypair"`
+	}
+	var s struct {
+		KeyPairs []pair `json:"keypairs"`
+	}
+	err := (r.(KeyPairPage)).ExtractInto(&s)
+	results := make([]KeyPair, len(s.KeyPairs))
+	for i, pair := range s.KeyPairs {
+		results[i] = pair.KeyPair
+	}
+	return results, err
+}
+
+type keyPairResult struct {
+	gophercloud.Result
+}
+
+// Extract is a method that attempts to interpret any KeyPair resource response
+// as a KeyPair struct.
+func (r keyPairResult) Extract() (*KeyPair, error) {
+	var s struct {
+		KeyPair *KeyPair `json:"keypair"`
+	}
+	err := r.ExtractInto(&s)
+	return s.KeyPair, err
+}
+
+// CreateResult is the response from a Create operation. Call its Extract method
+// to interpret it as a KeyPair.
+type CreateResult struct {
+	keyPairResult
+}
+
+// GetResult is the response from a Get operation. Call its Extract method to
+// interpret it as a KeyPair.
+type GetResult struct {
+	keyPairResult
+}
+
+// DeleteResult is the response from a Delete operation. Call its ExtractErr
+// method to determine if the call succeeded or failed.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/keypairs/urls.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/keypairs/urls.go
@@ -1,0 +1,25 @@
+package keypairs
+
+import "github.com/gophercloud/gophercloud"
+
+const resourcePath = "os-keypairs"
+
+func resourceURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL(resourcePath)
+}
+
+func listURL(c *gophercloud.ServiceClient) string {
+	return resourceURL(c)
+}
+
+func createURL(c *gophercloud.ServiceClient) string {
+	return resourceURL(c)
+}
+
+func getURL(c *gophercloud.ServiceClient, name string) string {
+	return c.ServiceURL(resourcePath, name)
+}
+
+func deleteURL(c *gophercloud.ServiceClient, name string) string {
+	return getURL(c, name)
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -387,6 +387,12 @@
 			"revisionTime": "2017-06-11T02:52:58Z"
 		},
 		{
+			"checksumSHA1": "jOyPWAJGRqLHofGLL/aiYBZzJR0=",
+			"path": "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/keypairs",
+			"revision": "afbf0422412f5dc726fa12be280fa0c3cb31fcbd",
+			"revisionTime": "2018-02-28T16:50:54Z"
+		},
+		{
 			"checksumSHA1": "vTyXSR+Znw7/o/70UBOWG0F09r8=",
 			"path": "github.com/gophercloud/gophercloud/openstack/compute/v2/flavors",
 			"revision": "64e5161c25fde7f0ccfb85f9af29ed22eeab4cd0",


### PR DESCRIPTION
Fixes #443.

Changes the OpenStack provider so that:
- It creates a keypair based on the given public key.
- Uses the created keypair with spawned instances.
- Removes the keypair when the kube is deleted.
