### PR TITLE
"Error in RecurringService" bug fix.

### DIFF
--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -14,10 +14,10 @@ import (
 	"github.com/supergiant/supergiant/pkg/model"
 	"github.com/supergiant/supergiant/pkg/util"
 
+	"github.com/creasty/defaults"
 	"github.com/jinzhu/gorm"
 	_ "github.com/jinzhu/gorm/dialects/postgres"
 	_ "github.com/jinzhu/gorm/dialects/sqlite"
-	"github.com/creasty/defaults"
 )
 
 type NodeSize struct {
@@ -131,7 +131,7 @@ func (c *Core) InitializeForeground() error {
 			return err
 		}
 		// Set Default Settings with struct tags
-		if err := defaults.Set(&c.Settings); err!= nil {
+		if err := defaults.Set(&c.Settings); err != nil {
 			return err
 		}
 	}
@@ -243,6 +243,7 @@ func (c *Core) InitializeBackground() {
 				WaitBeforeScale: 2 * time.Minute,
 			},
 			interval: 30 * time.Second,
+			tag:      "Capacity Service",
 		}
 		go capacityService.Run()
 	}
@@ -251,6 +252,7 @@ func (c *Core) InitializeBackground() {
 		core:     c,
 		service:  &NodeObserver{c},
 		interval: 30 * time.Second,
+		tag:      "Node Observer",
 	}
 	go nodeObserver.Run()
 
@@ -259,6 +261,7 @@ func (c *Core) InitializeBackground() {
 		core:     c,
 		fn:       c.KubeResources.Populate,
 		interval: 30 * time.Second,
+		tag:      "Kube Resource Populator",
 	}
 	go kubeResourcePopulater.Run()
 
@@ -266,6 +269,7 @@ func (c *Core) InitializeBackground() {
 		core:     c,
 		fn:       c.HelmCharts.Populate,
 		interval: 60 * time.Second,
+		tag:      "Helm Chart Populator",
 	}
 	go helmChartPopulater.Run()
 
@@ -273,6 +277,7 @@ func (c *Core) InitializeBackground() {
 		core:     c,
 		fn:       c.HelmReleases.Populate,
 		interval: 30 * time.Second,
+		tag:      "Helm Release Populator",
 	}
 	go helmReleasePopulater.Run()
 
@@ -280,6 +285,7 @@ func (c *Core) InitializeBackground() {
 		core:     c,
 		service:  &SessionExpirer{c},
 		interval: 15 * time.Second,
+		tag:      "Session Expire",
 	}
 	go sessionExpirer.Run()
 }

--- a/pkg/core/recurring_service.go
+++ b/pkg/core/recurring_service.go
@@ -14,9 +14,9 @@ type RecurringService struct {
 	core *Core
 
 	// can provide function directly (which takes priority), or Service interface
-	fn      func() error
-	service Service
-
+	fn       func() error
+	service  Service
+	tag      string
 	interval time.Duration
 }
 
@@ -30,7 +30,8 @@ func (s *RecurringService) Run() {
 func (s *RecurringService) tick() {
 	defer s.recover()
 	if err := s.perform(); err != nil {
-		s.core.Log.Error("Error in RecurringService "+s.name()+": ", err)
+
+		s.core.Log.Error("Error in RecurringService ["+s.tag+"] : ", err)
 	}
 }
 

--- a/pkg/kubernetes/types.go
+++ b/pkg/kubernetes/types.go
@@ -249,11 +249,11 @@ type ServiceSpec struct {
 }
 
 type ServicePort struct {
-	Name       string `json:"name"`
-	Port       int    `json:"port"`
-	Protocol   string `json:"protocol,omitempty"`
-	NodePort   int    `json:"nodePort,omitempty"`
-	TargetPort int    `json:"targetPort,omitempty"`
+	Name       string      `json:"name"`
+	Port       int         `json:"port"`
+	Protocol   string      `json:"protocol,omitempty"`
+	NodePort   int         `json:"nodePort,omitempty"`
+	TargetPort interface{} `json:"targetPort,omitempty"`
 }
 
 type ServiceStatus struct {


### PR DESCRIPTION
Fixes #434

This change adds some more helpful hints as to where the RecurringService
is running into errors by adding a "tag" attribute to RecurringService jobs.

example:

```
ERRO[0000] Error in RecurringService [Kube Resource Populator] : json: cannot unmarshal string into Go struct field ServicePort.targetPort of type int
ERRO[0031] Error in RecurringService [Kube Resource Populator] : json: cannot unmarshal string into Go struct field ServicePort.targetPort of type int
ERRO[0061] Error in RecurringService [Kube Resource Populator] : json: cannot unmarshal string into Go struct field ServicePort.targetPort of type int
ERRO[0091] Error in RecurringService [Kube Resource Populator] : json: cannot unmarshal string into Go struct field ServicePort.targetPort of type int
ERRO[0121] Error in RecurringService [Kube Resource Populator] : json: cannot unmarshal string into Go struct field ServicePort.targetPort of type int
```

This change also fixes the annoying bug listed in the example above by using a interface{}
in the service port type. This does not seem to cause an issue with any other services yet.

```
type ServicePort struct {
	Name       string      `json:"name"`
	Port       int         `json:"port"`
	Protocol   string      `json:"protocol,omitempty"`
	NodePort   int         `json:"nodePort,omitempty"`
	TargetPort interface{} `json:"targetPort,omitempty"`
}
```