### PR TITLE
Bug fix to coreOS images

### DIFF
--- a/pkg/provider/aws/provider.go
+++ b/pkg/provider/aws/provider.go
@@ -261,6 +261,12 @@ func getAMI(ec2S ec2iface.EC2API) (string, error) {
 				},
 			},
 			&ec2.Filter{
+				Name: aws.String("name"),
+				Values: []*string{
+					aws.String("*3.0*"),
+				},
+			},
+			&ec2.Filter{
 				Name: aws.String("virtualization-type"),
 				Values: []*string{
 					aws.String("hvm"),


### PR DESCRIPTION
CoreOS 4.0 break Supergiant. For now, images are limited to version 3.0. 