### PR TITLE
Load Balancer Proper listing properly.

### DIFF
--- a/cmd/ui/assets/src/app/pods/pods-list/pods-list.component.html
+++ b/cmd/ui/assets/src/app/pods/pods-list/pods-list.component.html
@@ -21,7 +21,7 @@
   </ngx-datatable-column>
   <ngx-datatable-column name="Name" prop="name"></ngx-datatable-column>
   <ngx-datatable-column name="Namespace" prop="namespace"></ngx-datatable-column>
-  <ngx-datatable-column name="Status" prop="status"></ngx-datatable-column>
+  <ngx-datatable-column name="Status" prop="passive_status"></ngx-datatable-column>
 </ngx-datatable>
 
 <context-menu #basicMenu>

--- a/cmd/ui/assets/src/app/pods/pods-list/pods-list.component.ts
+++ b/cmd/ui/assets/src/app/pods/pods-list/pods-list.component.ts
@@ -71,9 +71,26 @@ export class PodsListComponent implements OnInit, OnDestroy {
     this.subscriptions.add(Observable.timer(0, 5000)
       .switchMap(() => this.supergiant.KubeResources.get()).subscribe(
         (pods) => {
-          this.resources = pods.items.filter(
-            resource => resource.kube_name === this.kube.name && resource.kind === this.selectedResourceKind
-          ).map(resource => ({
+
+          // Filter by kube if it is passed, else no filter.
+          if (this.kube) {
+            this.resources = pods.items.filter(
+              resource =>
+                resource.kube_name === this.kube.name
+                && resource.kind === this.selectedResourceKind
+                || resource.kube_name === this.kube.name
+                && resource.resource.spec.type === this.selectedResourceKind
+            );
+          } else {
+            this.resources = pods.items.filter(
+              resource =>
+                resource.kind === this.selectedResourceKind
+                || resource.resource.spec.type === this.selectedResourceKind
+            );
+          }
+
+
+          this.resources.map(resource => ({
             id: resource.id,
             name: resource.name,
             namespace: resource.namespace,


### PR DESCRIPTION
Fixes #411

In Supergiant there are two types of LoadBalancer. Ones created and
ownded directly by Supergiant. And ones owned by Kubernetes. The ones
owned by Kubernetes as technically services. So have been only been
displayed on the services page. This change makes those Loadbalacers
show up in the LoadBalancer section of Supergiant to reduce confusion.