### PR TITLE
Fix helm release integration test

### DIFF
--- a/build/verify/gofmt.sh
+++ b/build/verify/gofmt.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/bin/bash
 # https://github.com/kubernetes/repo-infra/blob/master/verify/go-tools/verify-gofmt.sh
 
 set -o errexit

--- a/build/verify/goimports.sh
+++ b/build/verify/goimports.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/bin/bash
 
 set -o errexit
 set -o nounset

--- a/build/verify/gometalinter.sh
+++ b/build/verify/gometalinter.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/bin/bash
 
 set -o errexit
 set -o nounset

--- a/pkg/core/helm_releases.go
+++ b/pkg/core/helm_releases.go
@@ -16,6 +16,7 @@ import (
 	"github.com/supergiant/supergiant/pkg/kubernetes"
 	"github.com/supergiant/supergiant/pkg/model"
 	"github.com/supergiant/supergiant/pkg/util"
+	"sort"
 )
 
 type HelmReleases struct {
@@ -304,7 +305,17 @@ func releaseConfigAsFlagValue(config map[string]interface{}, parent string) (fv 
 		parent += "."
 	}
 
-	for key, value := range config {
+	// Sort keys before map traversal to have stable order of keys for tests.
+	keys := make([]string, len(config))
+
+	for key := range config {
+		keys = append(keys, key)
+	}
+
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		value := config[key]
 
 		if value == nil {
 			value = ""

--- a/pkg/core/helm_releases.go
+++ b/pkg/core/helm_releases.go
@@ -13,10 +13,11 @@ import (
 
 	"github.com/technosophos/moniker"
 
+	"sort"
+
 	"github.com/supergiant/supergiant/pkg/kubernetes"
 	"github.com/supergiant/supergiant/pkg/model"
 	"github.com/supergiant/supergiant/pkg/util"
-	"sort"
 )
 
 type HelmReleases struct {

--- a/pkg/core/helm_releases.go
+++ b/pkg/core/helm_releases.go
@@ -307,7 +307,7 @@ func releaseConfigAsFlagValue(config map[string]interface{}, parent string) (fv 
 	}
 
 	// Sort keys before map traversal to have stable order of keys for tests.
-	keys := make([]string, len(config))
+	keys := make([]string, 0, len(config))
 
 	for key := range config {
 		keys = append(keys, key)

--- a/pkg/core/helm_releases.go
+++ b/pkg/core/helm_releases.go
@@ -1,19 +1,17 @@
 package core
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"reflect"
 	"regexp"
+	"sort"
 	"strings"
 	"sync"
 	"time"
 
-	"context"
-
 	"github.com/technosophos/moniker"
-
-	"sort"
 
 	"github.com/supergiant/supergiant/pkg/kubernetes"
 	"github.com/supergiant/supergiant/pkg/model"

--- a/pkg/core/helm_releases_test.go
+++ b/pkg/core/helm_releases_test.go
@@ -1,0 +1,40 @@
+package core
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestReleaseConfigAsFlagValue(t *testing.T) {
+	testCases := []struct {
+		config   map[string]interface{}
+		expected string
+	}{
+		{
+			config: map[string]interface{}{
+				"nested": map[string]interface{}{
+					"key": "value",
+				},
+				"not-nested": 6,
+			},
+			expected: "nested.key='value',not-nested=6",
+		},
+		{
+			config: map[string]interface{}{
+				"nested": map[string]interface{}{
+					"key": "value",
+				},
+				"akey": 6,
+			},
+			expected: "akey=6,nested.key='value'",
+		},
+	}
+
+	for _, testCase := range testCases {
+		actual := releaseConfigAsFlagValue(testCase.config, "")
+
+		if !strings.EqualFold(actual, testCase.expected) {
+			t.Errorf("Wrong keys string expected %s actual %s", testCase.expected, actual)
+		}
+	}
+}


### PR DESCRIPTION
Sort config map keys to stabilize key traversal order and make test repeatable