### PR TITLE
Synchronize creating of new server

### DIFF
--- a/test/providers/testutils_test.go
+++ b/test/providers/testutils_test.go
@@ -5,6 +5,7 @@ package providers
 import (
 	"fmt"
 	"net"
+	"sync"
 
 	"github.com/sirupsen/logrus"
 
@@ -18,6 +19,10 @@ import (
 	"github.com/supergiant/supergiant/pkg/provider/openstack"
 	"github.com/supergiant/supergiant/pkg/provider/packet"
 	"github.com/supergiant/supergiant/pkg/server"
+)
+
+var (
+	m sync.Mutex
 )
 
 func getPort() (int, error) {
@@ -91,6 +96,9 @@ func newServer() (*server.Server, error) {
 
 	c.K8SProvider = &kubernetes.Provider{Core: c}
 
+	// Protect this section to avoid race condition over dialect_sqlite3.go:40
+	m.Lock()
+	defer m.Unlock()
 	if err := c.InitializeForeground(); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Race condition happens due to concurrent access to sqlite internals

```
goroutine 35 [running]:
runtime.throw(0x1c0b472, 0x15)
	/home/travis/.gimme/versions/go1.10.linux.amd64/src/runtime/panic.go:619 +0x81 fp=0xc4209173e0 sp=0xc4209173c0 pc=0x434aa1
runtime.mapassign_faststr(0x190d320, 0xc4209b8120, 0x1bfe0f0, 0xe, 0x0)
	/home/travis/.gimme/versions/go1.10.linux.amd64/src/runtime/hashmap_fast.go:779 +0x3ce fp=0xc420917450 sp=0xc4209173e0 pc=0x41558e
github.com/supergiant/supergiant/vendor/github.com/jinzhu/gorm.sqlite3.DataTypeOf(0xc4203b1540, 0xc4209cfbb0, 0xc420635110, 0x46cc2d, 0xc4209175c0)
	/home/travis/gopath/src/github.com/supergiant/supergiant/vendor/github.com/jinzhu/gorm/dialect_sqlite3.go:40 +0x3b8 fp=0xc420917588 sp=0xc420917450 pc=0xb20128
github.com/supergiant/supergiant/vendor/github.com/jinzhu/gorm.(*sqlite3).DataTypeOf(0xc4204bf760, 0xc420635110, 0xc4209cfbb0, 0xc4209cfbb0)
	<autogenerated>:1 +0x46 fp=0xc4209175c0 sp=0xc420917588 pc=0xb489f6
github.com/supergiant/supergiant/vendor/github.com/jinzhu/gorm.(*Scope).createTable(0xc42041fa80, 0xc4200cbd38)
	/home/travis/gopath/src/github.com/supergiant/supergiant/vendor/github.com/jinzhu/gorm/scope.go:1067 +0x287 fp=0xc420917740 sp=0xc4209175c0 pc=0xb39d97
github.com/supergiant/supergiant/vendor/github.com/jinzhu/gorm.(*Scope).autoMigrate(0xc42041fa80, 0x19e5c60)
	/home/travis/gopath/src/github.com/supergiant/supergiant/vendor/github.com/jinzhu/gorm/scope.go:1146 +0x3c7 fp=0xc420917838 sp=0xc420917740 pc=0xb3b4b7
github.com/supergiant/supergiant/vendor/github.com/jinzhu/gorm.(*DB).AutoMigrate(0xc4203b12c0, 0xc420917a28, 0x9, 0x9, 0x1)
	/home/travis/gopath/src/github.com/supergiant/supergiant/vendor/github.com/jinzhu/gorm/main.go:525 +0x6f fp=0xc420917878 sp=0xc420917838 pc=0xb290ef
github.com/supergiant/supergiant/pkg/core.(*Core).InitializeForeground(0xc4202a6800, 0xc4200cec68, 0xc420083d30)
	/home/travis/gopath/src/github.com/supergiant/supergiant/pkg/core/core.go:187 +0x6bd fp=0xc420917cd8 sp=0xc420917878 pc=0x103f67d
github.com/supergiant/supergiant/test/providers.newServer(0x1822a00, 0xc420294cc0, 0xc4200480ce)
	/home/travis/gopath/src/github.com/supergiant/supergiant/test/providers/testutils_test.go:94 +0x3b5 fp=0xc420917e50 sp=0xc420917cd8 pc=0x160ade5
github.com/supergiant/supergiant/test/providers.TestGCE(0xc4206002d0)
	/home/travis/gopath/src/github.com/supergiant/supergiant/test/providers/gce_test.go:33 +0x1ef fp=0xc420917fa8 sp=0xc420917e50 pc=0x160a09f
testing.tRunner(0xc4206002d0, 0x1c98c40)
	/home/travis/.gimme/versions/go1.10.linux.amd64/src/testing/testing.go:777 +0xd0 fp=0xc420917fd0 sp=0xc420917fa8 pc=0x4fc850
runtime.goexit()
	/home/travis/.gimme/versions/go1.10.linux.amd64/src/runtime/asm_amd64.s:2361 +0x1 fp=0xc420917fd8 sp=0xc420917fd0 pc=0x463ad1
created by testing.(*T).Run
	/home/travis/.gimme/versions/go1.10.linux.amd64/src/testing/testing.go:824 +0x2e0
```