### PR TITLE
Fix panic in node observer

### DIFF
--- a/pkg/core/node_observer.go
+++ b/pkg/core/node_observer.go
@@ -83,16 +83,16 @@ func (s *NodeObserver) Perform() error {
 				}
 			}
 
-			// Set ExternalIP
-			for _, addr := range knode.Status.Addresses {
-				if addr.Type == "ExternalIP" {
-					node.ExternalIP = addr.Address
-					break
+			if knode != nil {
+				// Set ExternalIP
+				for _, addr := range knode.Status.Addresses {
+					if addr.Type == "ExternalIP" {
+						node.ExternalIP = addr.Address
+						break
+					}
 				}
-			}
 
-			// Set OutOfDisk
-			if len(knode.Status.Conditions) > 0 {
+				// Set OutOfDisk
 				for _, condition := range knode.Status.Conditions {
 					if condition.Type == "OutOfDisk" {
 						node.OutOfDisk = condition.Status == "True"


### PR DESCRIPTION
Get kubernetes node parameters only if node is found.
Fixes this panic:
```
goroutine 277 [running]:
runtime/debug.Stack(0xc4200d3d10, 0xc423a29870, 0x2)
        /home/unknown/goroot/go1.10.3/src/runtime/debug/stack.go:24 +0xa7
github.com/supergiant/supergiant/pkg/core.(*RecurringService).recover(0xc420425ec0)
        /home/unknown/go/src/github.com/supergiant/supergiant/pkg/core/recurring_service.go:56 +0x17c
panic(0x1921500, 0x2c64820)
        /home/unknown/goroot/go1.10.3/src/runtime/panic.go:502 +0x229
github.com/supergiant/supergiant/pkg/core.(*NodeObserver).Perform(0xc420905248, 0x1be8de7, 0xc421e61ef8)
        /home/unknown/go/src/github.com/supergiant/supergiant/pkg/core/node_observer.go:87 +0xaf6
github.com/supergiant/supergiant/pkg/core.(*RecurringService).perform(0xc420425ec0, 0x1c853a0, 0xc420425ec0)
        /home/unknown/go/src/github.com/supergiant/supergiant/pkg/core/recurring_service.go:42 +0x5f
github.com/supergiant/supergiant/pkg/core.(*RecurringService).tick(0xc420425ec0)
        /home/unknown/go/src/github.com/supergiant/supergiant/pkg/core/recurring_service.go:32 +0x6d
github.com/supergiant/supergiant/pkg/core.(*RecurringService).Run(0xc420425ec0)
        /home/unknown/go/src/github.com/supergiant/supergiant/pkg/core/recurring_service.go:26 +0x80
created by github.com/supergiant/supergiant/pkg/core.(*Core).InitializeBackground
        /home/unknown/go/src/github.com/supergiant/supergiant/pkg/core/core.go:294 +0x106
```