### PR TITLE
Fix a field name for helm releases

### DIFF
--- a/cmd/ui/assets/src/app/clusters/clusters-list/clusters-list.component.ts
+++ b/cmd/ui/assets/src/app/clusters/clusters-list/clusters-list.component.ts
@@ -227,7 +227,7 @@ export class ClustersListComponent implements OnInit, OnDestroy {
             version: kube.kubernetes_version,
             cloudaccount: kube.cloud_account_name,
             nodes: this.lengthOrZero(kube.nodes),
-            apps: this.lengthOrZero(kube.helmreleases),
+            apps: this.lengthOrZero(kube.helm_releases),
             status: this.titleCase.transform(this.progressOrDone(kube)),
             kube: kube,
             chartData: [


### PR DESCRIPTION
UI doesn't show a number of running apps, because uses an invalid field name for helm releases.