### PR TITLE
Delete a cluster with running apps with a 'force' param.

### DIFF
--- a/pkg/api/kubes_controller.go
+++ b/pkg/api/kubes_controller.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/supergiant/supergiant/pkg/core"
 	"github.com/supergiant/supergiant/pkg/model"
@@ -68,7 +69,8 @@ func DeleteKube(core *core.Core, user *model.User, r *http.Request) (*Response, 
 	if err != nil {
 		return nil, err
 	}
-	if err := core.Kubes.Delete(id, item).Async(); err != nil {
+	force := "true" == strings.TrimSpace(r.URL.Query().Get("force"))
+	if err := core.Kubes.Delete(id, item, force).Async(); err != nil {
 		return nil, err
 	}
 	return itemResponse(core, item, http.StatusAccepted)

--- a/pkg/core/helm_releases.go
+++ b/pkg/core/helm_releases.go
@@ -164,8 +164,6 @@ func (c *HelmReleases) Delete(id *int64, m *model.HelmRelease) ActionInterface {
 				if err != nil {
 					return errors.Wrapf(err, "delete %s release", m.Name)
 				}
-
-				log.Debugf("DEBUG - Delete %s release: %s", m.Name, resp.Info)
 			}
 			return c.Collection.Delete(id, m)
 		},


### PR DESCRIPTION
Supergiant doesn't delete apps (helm releases) before cluster deletion, that can lead to failure during this process.
To fix it, was added a check for running apps in a cluster and return an error if any exists.
To delete helm releases during a cluster deletion process, provide a query parameter 'force=true'.