### PR TITLE
Cluster deletion: add timeout to ensure removing provider resources

### DIFF
--- a/pkg/core/kubes.go
+++ b/pkg/core/kubes.go
@@ -3,6 +3,7 @@ package core
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 
@@ -77,6 +78,12 @@ func (c *Kubes) Delete(id *int64, m *model.Kube, force bool) ActionInterface {
 				if err := c.Core.HelmReleases.Delete(r.ID, r).Now(); err != nil {
 					return err
 				}
+			}
+
+			// Give kubernetes a little time to remove cloud provider resources
+			// TODO: check all "load balancer" services are deleted
+			if len(releases) > 0 {
+				time.Sleep(time.Minute)
 			}
 
 			// Delete Kube Resources directly (don't use provisioner Teardown)


### PR DESCRIPTION
This change is going to fix an issue, when sending a delete request to `kubes/11?force=true, supergiant is not be able to delete the vpc:
```
time="2018-07-05T19:56:06-05:00" level=info msg="Running step of Delete Kube procedure: deleting VPC"
time="2018-07-05T19:56:06-05:00" level=error msg="DependencyViolation: The vpc 'vpc-8788c0e0' has dependencies and cannot be deleted.\n\tstatus code: 400, request id: ebaed053-6746-4598-809c-d11dc1ad765f"
```
supergiant terminates a master node before it removes a cloud provider dependencies (AWS SG in this case). Add a little timeout to give kubernetes some time for removing cloud provider resources.