### PR TITLE
Rollback for steps 

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -34,14 +34,14 @@ func buildKubeConfig(addr string, auth Auth) clientcmddapi.Config {
 	return clientcmddapi.Config{
 		AuthInfos: map[string]*clientcmddapi.AuthInfo{
 			auth.Username: {
-				Token: auth.Token,
+				Token:                 auth.Token,
 				ClientCertificateData: []byte(auth.Cert),
 				ClientKeyData:         []byte(auth.Key),
 			},
 		},
 		Clusters: map[string]*clientcmddapi.Cluster{
 			auth.Username: {
-				Server: addr,
+				Server:                   addr,
 				CertificateAuthorityData: []byte(auth.CA),
 			},
 		},

--- a/pkg/workflows/steps/certificates/certificates.go
+++ b/pkg/workflows/steps/certificates/certificates.go
@@ -17,6 +17,10 @@ type Step struct {
 	script *template.Template
 }
 
+func (s *Step) Rollback(context.Context, io.Writer, *steps.Config) error {
+	return nil
+}
+
 func Init() {
 	steps.RegisterStep(StepName, New(tm.GetTemplate(StepName)))
 }

--- a/pkg/workflows/steps/cni/cni.go
+++ b/pkg/workflows/steps/cni/cni.go
@@ -17,6 +17,10 @@ type Step struct {
 	script *template.Template
 }
 
+func (s *Step) Rollback(context.Context, io.Writer, *steps.Config) error {
+	return nil
+}
+
 func Init() {
 	steps.RegisterStep(StepName, New(tm.GetTemplate(StepName)))
 }

--- a/pkg/workflows/steps/digitalocean/digital_ocean.go
+++ b/pkg/workflows/steps/digitalocean/digital_ocean.go
@@ -122,6 +122,10 @@ func (t *Step) Run(ctx context.Context, output io.Writer, config *steps.Config) 
 	return nil
 }
 
+func (t *Step) Rollback(context.Context, io.Writer, *steps.Config) error {
+	return nil
+}
+
 func (t *Step) tagDroplet(tagService godo.TagsService, dropletId int, tags []string) error {
 	// Tag droplet
 	for _, tag := range tags {

--- a/pkg/workflows/steps/docker/docker.go
+++ b/pkg/workflows/steps/docker/docker.go
@@ -37,6 +37,10 @@ func (t *Step) Run(ctx context.Context, out io.Writer, config *steps.Config) err
 	return nil
 }
 
+func (t *Step) Rollback(context.Context, io.Writer, *steps.Config) error {
+	return nil
+}
+
 func (t *Step) Name() string {
 	return StepName
 }

--- a/pkg/workflows/steps/downloadk8sbinary/download_k8s_binary.go
+++ b/pkg/workflows/steps/downloadk8sbinary/download_k8s_binary.go
@@ -37,6 +37,10 @@ func (s *Step) Run(ctx context.Context, out io.Writer, config *steps.Config) err
 	return nil
 }
 
+func (s *Step) Rollback(context.Context, io.Writer, *steps.Config) error {
+	return nil
+}
+
 func (s *Step) Name() string {
 	return StepName
 }

--- a/pkg/workflows/steps/etcd/etcd.go
+++ b/pkg/workflows/steps/etcd/etcd.go
@@ -38,6 +38,10 @@ func (s *Step) Run(ctx context.Context, out io.Writer, config *steps.Config) err
 	return nil
 }
 
+func (s *Step) Rollback(context.Context, io.Writer, *steps.Config) error {
+	return nil
+}
+
 func (s *Step) Name() string {
 	return StepName
 }

--- a/pkg/workflows/steps/flannel/flannel.go
+++ b/pkg/workflows/steps/flannel/flannel.go
@@ -39,6 +39,10 @@ func (t *Step) Run(ctx context.Context, out io.Writer, config *steps.Config) err
 	return nil
 }
 
+func (t *Step) Rollback(context.Context, io.Writer, *steps.Config) error {
+	return nil
+}
+
 func (t *Step) Name() string {
 	return StepName
 }
@@ -47,6 +51,6 @@ func (t *Step) Description() string {
 	return ""
 }
 
-func (s *Step) Depends() []string {
+func (t *Step) Depends() []string {
 	return []string{etcd.StepName, network.StepName}
 }

--- a/pkg/workflows/steps/kubelet/kubelet.go
+++ b/pkg/workflows/steps/kubelet/kubelet.go
@@ -42,6 +42,10 @@ func (t *Step) Run(ctx context.Context, out io.Writer, config *steps.Config) err
 	return nil
 }
 
+func (s *Step) Rollback(context.Context, io.Writer, *steps.Config) error {
+	return nil
+}
+
 func (t *Step) Name() string {
 	return StepName
 }

--- a/pkg/workflows/steps/manifest/manifest.go
+++ b/pkg/workflows/steps/manifest/manifest.go
@@ -44,6 +44,10 @@ func (j *Step) Run(ctx context.Context, out io.Writer, config *steps.Config) err
 	return nil
 }
 
+func (s *Step) Rollback(context.Context, io.Writer, *steps.Config) error {
+	return nil
+}
+
 func (t *Step) Name() string {
 	return StepName
 }

--- a/pkg/workflows/steps/network/network.go
+++ b/pkg/workflows/steps/network/network.go
@@ -42,6 +42,10 @@ func (t *Step) Name() string {
 	return StepName
 }
 
+func (s *Step) Rollback(context.Context, io.Writer, *steps.Config) error {
+	return nil
+}
+
 func (t *Step) Description() string {
 	return ""
 }

--- a/pkg/workflows/steps/poststart/post_start.go
+++ b/pkg/workflows/steps/poststart/post_start.go
@@ -46,6 +46,10 @@ func (s *Step) Name() string {
 	return StepName
 }
 
+func (s *Step) Rollback(context.Context, io.Writer, *steps.Config) error {
+	return nil
+}
+
 func (s *Step) Description() string {
 	return ""
 }

--- a/pkg/workflows/steps/ssh/ssh.go
+++ b/pkg/workflows/steps/ssh/ssh.go
@@ -41,6 +41,10 @@ func (s *Step) Name() string {
 	return StepName
 }
 
+func (s *Step) Rollback(context.Context, io.Writer, *steps.Config) error {
+	return nil
+}
+
 func (s *Step) Description() string {
 	return ""
 }

--- a/pkg/workflows/steps/step.go
+++ b/pkg/workflows/steps/step.go
@@ -20,6 +20,7 @@ type Step interface {
 	Name() string
 	Description() string
 	Depends() []string
+	Rollback(context.Context, io.Writer, *Config) error
 }
 
 var (

--- a/pkg/workflows/steps/tiller/tiller.go
+++ b/pkg/workflows/steps/tiller/tiller.go
@@ -48,6 +48,10 @@ func (s *Step) Name() string {
 	return StepName
 }
 
+func (s *Step) Rollback(context.Context, io.Writer, *steps.Config) error {
+	return nil
+}
+
 func (s *Step) Description() string {
 	return ""
 }

--- a/pkg/workflows/task.go
+++ b/pkg/workflows/task.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pborman/uuid"
 	"github.com/sirupsen/logrus"
 
+	"github.com/pkg/errors"
 	"github.com/supergiant/supergiant/pkg/storage"
 	"github.com/supergiant/supergiant/pkg/workflows/steps"
 )
@@ -59,6 +60,7 @@ func (w *Task) Run(ctx context.Context, config steps.Config, out io.Writer) chan
 				if err := w.sync(ctx); err != nil {
 					logrus.Errorf("sync error %v for task %s", err, w.ID)
 				}
+				errChan <- errors.Errorf("provisioning failed, unexpected panic: %v ", r)
 			}
 		}()
 		if w == nil {

--- a/pkg/workflows/task.go
+++ b/pkg/workflows/task.go
@@ -67,7 +67,7 @@ func (w *Task) Run(ctx context.Context, config steps.Config, out io.Writer) chan
 			return
 		}
 
-		// Create list of*Step statuses to track
+		// Create list of statuses to track
 		for _, step := range w.workflow {
 			w.StepStatuses = append(w.StepStatuses, StepStatus{
 				Status:   steps.StatusTodo,
@@ -158,7 +158,7 @@ func (w *Task) startFrom(ctx context.Context, id string, out io.Writer, i int) e
 			}
 
 			if err3 := step.Rollback(ctx, out, w.Config); err3 != nil {
-				logrus.Errorf("rollback error %v for step %s", err3, step.Name())
+				logrus.Errorf("rollback: step %s : %v", step.Name(), err3)
 			}
 
 			return err

--- a/pkg/workflows/task_test.go
+++ b/pkg/workflows/task_test.go
@@ -281,3 +281,45 @@ func TestRollback(t *testing.T) {
 
 	require.True(t, mockStep.rollback)
 }
+
+type PanicStep struct {
+}
+
+func (PanicStep) Run(context.Context, io.Writer, *steps.Config) error {
+	panic("implement me")
+}
+
+func (PanicStep) Name() string {
+	panic("implement me")
+}
+
+func (PanicStep) Description() string {
+	panic("implement me")
+}
+
+func (PanicStep) Depends() []string {
+	panic("implement me")
+}
+
+func (PanicStep) Rollback(context.Context, io.Writer, *steps.Config) error {
+	panic("implement me")
+}
+
+func TestPanicHandler(t *testing.T) {
+	s := &MockRepository{
+		storage: make(map[string][]byte),
+	}
+
+	step := &PanicStep{}
+	task := &Task{
+		ID:         "XYZ",
+		repository: s,
+		workflow: []steps.Step{
+			step,
+		},
+	}
+	errChan := task.Run(context.Background(), steps.Config{}, &bytes.Buffer{})
+
+	err := <-errChan
+	require.Error(t, err)
+}


### PR DESCRIPTION
Added rollback feature to workflows framework. Rollback method would be called if run has returned error thus making a certain step idempotent. For instance if provisioning failed we don't need that instance (EC2, droplet, etc) and it could be deleted automatically.

Also, added panic handler in case some step panics it would mark entire provisioning as failed.