### PR TITLE
Expose prometheus outside

### DIFF
--- a/pkg/kube/handler.go
+++ b/pkg/kube/handler.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"gopkg.in/asaskevich/govalidator.v8"
 
+	"crypto/tls"
 	"github.com/supergiant/supergiant/pkg/clouds"
 	"github.com/supergiant/supergiant/pkg/message"
 	"github.com/supergiant/supergiant/pkg/model"
@@ -25,6 +26,7 @@ import (
 	"github.com/supergiant/supergiant/pkg/workflows"
 	"github.com/supergiant/supergiant/pkg/workflows/statuses"
 	"github.com/supergiant/supergiant/pkg/workflows/steps"
+	"strings"
 )
 
 type accountGetter interface {
@@ -81,6 +83,8 @@ func (h *Handler) Register(r *mux.Router) {
 
 	r.HandleFunc("/kubes/{kname}/nodes", h.addNode).Methods(http.MethodPost)
 	r.HandleFunc("/kubes/{kname}/nodes/{nodename}", h.deleteNode).Methods(http.MethodDelete)
+	r.HandleFunc("/kubes/{kname}/metrics", h.getClusterMetrics).Methods(http.MethodGet)
+	r.HandleFunc("/kubes/{kname}/{nodename}/metrics", h.getNodeMetrics).Methods(http.MethodGet)
 }
 
 func (h *Handler) getTasks(w http.ResponseWriter, r *http.Request) {
@@ -642,5 +646,167 @@ func (h *Handler) deleteReleases(w http.ResponseWriter, r *http.Request) {
 	if err = json.NewEncoder(w).Encode(rls); err != nil {
 		logrus.Errorf("helm: delete release: %s cluster: write response: %s", kname, err)
 		message.SendUnknownError(w, err)
+	}
+}
+
+type MetricResponse struct {
+	Status string `json:"status"`
+	Data   struct {
+		ResultType string `json:"resultType"`
+		Result     []struct {
+			Metric map[string]string `json:"metric"`
+			Value  []interface{}     `json:"value"`
+		} `json:"result"`
+	} `json:"data"`
+}
+
+func (h *Handler) getClusterMetrics(w http.ResponseWriter, r *http.Request) {
+	var (
+		relativeUrls = map[string]string{
+			"cpu":    "api/v1/query?query=:node_cpu_utilisation:avg1m",
+			"memory": "api/v1/query?query=:node_memory_utilisation:",
+		}
+		masterNode     *node.Node
+		metricResponse = &MetricResponse{}
+		response       = map[string]interface{}{}
+		baseUrl        = "api/v1/namespaces/default/services/prometheus-operated:9090/proxy"
+	)
+
+	vars := mux.Vars(r)
+	kname := vars["kname"]
+
+	k, err := h.svc.Get(r.Context(), kname)
+	if err != nil {
+		if sgerrors.IsNotFound(err) {
+			message.SendNotFound(w, kname, err)
+			return
+		}
+		message.SendUnknownError(w, err)
+		return
+	}
+
+	for key := range k.Masters {
+		if k.Masters[key] != nil {
+			masterNode = k.Masters[key]
+		}
+	}
+
+	for metricType, relUrl := range relativeUrls {
+		url := fmt.Sprintf("https://%s/%s/%s", masterNode.PublicIp, baseUrl, relUrl)
+		req, err := http.NewRequest(http.MethodGet, url, nil)
+
+		if err != nil {
+			message.SendUnknownError(w, err)
+			return
+		}
+
+		req.SetBasicAuth("root", "1234")
+		tr := &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		}
+		client := &http.Client{
+			Transport: tr,
+		}
+		resp, err := client.Do(req)
+
+		if err != nil {
+			message.SendUnknownError(w, err)
+			return
+		}
+
+		err = json.NewDecoder(resp.Body).Decode(metricResponse)
+
+		if err != nil {
+			logrus.Error(err)
+			message.SendInvalidJSON(w, err)
+			return
+		}
+
+		response[metricType] = metricResponse.Data.Result[0].Value[1]
+	}
+
+	err = json.NewEncoder(w).Encode(response)
+
+	if err != nil {
+		message.SendUnknownError(w, err)
+		return
+	}
+}
+
+func (h *Handler) getNodeMetrics(w http.ResponseWriter, r *http.Request) {
+	var (
+		relativeUrls = map[string]string{
+			"cpu":    "api/v1/query?query=node:node_cpu_utilisation:avg1m",
+			"memory": "api/v1/query?query=node:node_memory_utilisation:",
+		}
+		masterNode     *node.Node
+		metricResponse = &MetricResponse{}
+		response       = map[string]interface{}{}
+		baseUrl        = "api/v1/namespaces/default/services/prometheus-operated:9090/proxy"
+	)
+
+	vars := mux.Vars(r)
+	kname := vars["kname"]
+	nodeName := vars["nodename"]
+
+	k, err := h.svc.Get(r.Context(), kname)
+	if err != nil {
+		if sgerrors.IsNotFound(err) {
+			message.SendNotFound(w, kname, err)
+			return
+		}
+		message.SendUnknownError(w, err)
+		return
+	}
+
+	for key := range k.Masters {
+		if k.Masters[key] != nil {
+			masterNode = k.Masters[key]
+		}
+	}
+
+	for metricType, relUrl := range relativeUrls {
+		url := fmt.Sprintf("https://%s/%s/%s", masterNode.PublicIp, baseUrl, relUrl)
+		req, err := http.NewRequest(http.MethodGet, url, nil)
+
+		if err != nil {
+			message.SendUnknownError(w, err)
+			return
+		}
+
+		req.SetBasicAuth("root", "1234")
+		tr := &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		}
+		client := &http.Client{
+			Transport: tr,
+		}
+		resp, err := client.Do(req)
+
+		if err != nil {
+			message.SendUnknownError(w, err)
+			return
+		}
+
+		err = json.NewDecoder(resp.Body).Decode(metricResponse)
+
+		if err != nil {
+			logrus.Error(err)
+			message.SendInvalidJSON(w, err)
+			return
+		}
+
+		for _, result := range metricResponse.Data.Result {
+			if strings.EqualFold(result.Metric["node"], nodeName) {
+				response[metricType] = result.Value[1]
+			}
+		}
+	}
+
+	err = json.NewEncoder(w).Encode(response)
+
+	if err != nil {
+		message.SendUnknownError(w, err)
+		return
 	}
 }

--- a/pkg/kube/handler.go
+++ b/pkg/kube/handler.go
@@ -700,6 +700,7 @@ func (h *Handler) getClusterMetrics(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
+		// TODO(stgleb): Get rid off basic auth
 		req.SetBasicAuth("root", "1234")
 		tr := &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
@@ -776,6 +777,7 @@ func (h *Handler) getNodeMetrics(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
+		// TODO(stgleb): Get rid off basic auth
 		req.SetBasicAuth("root", "1234")
 		tr := &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},

--- a/pkg/kube/handler.go
+++ b/pkg/kube/handler.go
@@ -722,7 +722,9 @@ func (h *Handler) getClusterMetrics(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		response[metricType] = metricResponse.Data.Result[0].Value[1]
+		if len(metricResponse.Data.Result) > 0 && len(metricResponse.Data.Result[0].Value) > 1 {
+			response[metricType] = metricResponse.Data.Result[0].Value[1]
+		}
 	}
 
 	err = json.NewEncoder(w).Encode(response)

--- a/pkg/workflows/steps/config.go
+++ b/pkg/workflows/steps/config.go
@@ -152,7 +152,8 @@ type ClusterCheckConfig struct {
 }
 
 type PrometheusConfig struct {
-	RBACEnabled bool `json:"rbacEnabled"`
+	Port        string `json:"port"`
+	RBACEnabled bool   `json:"rbacEnabled"`
 }
 
 type Map struct {
@@ -313,6 +314,7 @@ func NewConfig(clusterName, discoveryUrl, cloudAccountName string, profile profi
 			MachineCount: len(profile.NodesProfiles) + len(profile.MasterProfiles),
 		},
 		PrometheusConfig: PrometheusConfig{
+			Port:        "30900",
 			RBACEnabled: profile.RBACEnabled,
 		},
 

--- a/pkg/workflows/steps/prometheus/prometheus_test.go
+++ b/pkg/workflows/steps/prometheus/prometheus_test.go
@@ -76,10 +76,6 @@ func TestPrometheusRBACDisbled(t *testing.T) {
 	if !strings.Contains(output.String(), "sudo kubectl apply -f cluster-roles.yaml --validate=false") {
 		t.Errorf("command for creating roles not found in %s", output.String())
 	}
-
-	if !strings.Contains(output.String(), promPort) {
-		t.Errorf("Prometheus port %s not found in %s", promPort, output.String())
-	}
 }
 
 func TestPrometheusRBACEnabled(t *testing.T) {
@@ -123,10 +119,6 @@ func TestPrometheusRBACEnabled(t *testing.T) {
 
 	if !strings.Contains(output.String(), "prometheus-operator") {
 		t.Errorf("not found %s in %s", "prometheus-operator", output.String())
-	}
-
-	if !strings.Contains(output.String(), promPort) {
-		t.Errorf("Prometheus port %s not found in %s", promPort, output.String())
 	}
 }
 

--- a/templates/prometheus.sh.tpl
+++ b/templates/prometheus.sh.tpl
@@ -4,22 +4,3 @@ sudo kubectl apply -f cluster-roles.yaml --validate=false
 {{end}}
 sleep 60
 sudo /opt/bin/helm install stable/prometheus-operator
-
-sudo bash -c "cat << EOF > prometheus.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: prometheus
-spec:
-  type: NodePort
-  ports:
-  - name: web
-    nodePort: {{ .Port }}
-    port: 9090
-    protocol: TCP
-    targetPort: web
-  selector:
-    app: prometheus
-EOF"
-
-sudo kubectl create -f prometheus.yaml

--- a/templates/prometheus.sh.tpl
+++ b/templates/prometheus.sh.tpl
@@ -2,6 +2,7 @@
 wget https://raw.githubusercontent.com/kubernetes/kubernetes/release-1.12/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
 sudo kubectl apply -f cluster-roles.yaml --validate=false
 {{end}}
+sleep 60
 sudo /opt/bin/helm install stable/prometheus-operator
 
 sudo bash -c "cat << EOF > prometheus.yaml
@@ -21,4 +22,4 @@ spec:
     app: prometheus
 EOF"
 
-sudo kubectl -f create prometheus.yaml
+sudo kubectl create -f prometheus.yaml

--- a/templates/prometheus.sh.tpl
+++ b/templates/prometheus.sh.tpl
@@ -2,5 +2,23 @@
 wget https://raw.githubusercontent.com/kubernetes/kubernetes/release-1.12/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
 sudo kubectl apply -f cluster-roles.yaml --validate=false
 {{end}}
-sleep 120
 sudo /opt/bin/helm install stable/prometheus-operator
+
+sudo bash -c "cat << EOF > prometheus.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus
+spec:
+  type: NodePort
+  ports:
+  - name: web
+    nodePort: {{ .Port }}
+    port: 9090
+    protocol: TCP
+    targetPort: web
+  selector:
+    app: prometheus
+EOF"
+
+sudo kubectl -f create prometheus.yaml


### PR DESCRIPTION
Data format

```
clustewide metrics 
GET /v1/api/kubes/{kubeName}/metrics

response {"cpu":"0.07544444444444376","memory":"0.23282472808608834"}

node metrics

GET /v1/api/kubes/{kubeName}/{nodeName}/metrics

response

{"cpu":"0.13800000000000145","memory":"0.4090085304502703"}
```

NOTE: prometheus nees some time to ramp up and give a metrics, it can take ~30-40 seconds