### PR TITLE
Use CoreDNS as the kube-dns component

### DIFF
--- a/templates/manifest.sh.tpl
+++ b/templates/manifest.sh.tpl
@@ -4,19 +4,184 @@ KUBERNETES_ADDONS_DIR={{ .KubernetesConfigDir }}/addons
 ADDON=${KUBERNETES_ADDONS_DIR}/'kube-dns'
 sudo mkdir -p ${ADDON}
 sudo bash -c "cat << EOF > ${ADDON}/kube-dns.yaml
+# https://github.com/kubernetes/kubernetes/tree/master/cluster/addons/dns/coredns
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: coredns
+  namespace: kube-system
+  labels:
+    kubernetes.io/cluster-service: 'true'
+    addonmanager.kubernetes.io/mode: Reconcile
+{{if .RBACEnabled }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    kubernetes.io/bootstrapping: rbac-defaults
+    addonmanager.kubernetes.io/mode: Reconcile
+  name: system:coredns
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - endpoints
+  - services
+  - pods
+  - namespaces
+  verbs:
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: 'true'
+  labels:
+    kubernetes.io/bootstrapping: rbac-defaults
+    addonmanager.kubernetes.io/mode: EnsureExists
+  name: system:coredns
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:coredns
+subjects:
+- kind: ServiceAccount
+  name: coredns
+  namespace: kube-system
+{{ end }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coredns
+  namespace: kube-system
+  labels:
+      addonmanager.kubernetes.io/mode: EnsureExists
+data:
+  Corefile: |
+    .:53 {
+        # to log queries enable a log plugin
+        #log
+        errors
+        health
+        kubernetes cluster.local in-addr.arpa ip6.arpa {
+            pods insecure
+            upstream
+            fallthrough in-addr.arpa ip6.arpa
+        }
+        prometheus :9153
+        proxy . /etc/resolv.conf
+        cache 30
+        reload
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: coredns
+  namespace: kube-system
+  labels:
+    k8s-app: kube-dns
+    kubernetes.io/cluster-service: 'true'
+    addonmanager.kubernetes.io/mode: Reconcile
+    kubernetes.io/name: CoreDNS
+spec:
+  # replicas: not specified here:
+  # 1. In order to make Addon Manager do not reconcile this replicas parameter.
+  # 2. Default is 1.
+  # 3. Will be tuned in real time if DNS horizontal auto-scaling is turned on.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      k8s-app: kube-dns
+  template:
+    metadata:
+      labels:
+        k8s-app: kube-dns
+      annotations:
+        seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
+    spec:
+      serviceAccountName: coredns
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+        - key: CriticalAddonsOnly
+          operator: Exists
+      containers:
+      - name: coredns
+        image: k8s.gcr.io/coredns:1.2.4
+        imagePullPolicy: IfNotPresent
+        resources:
+          limits:
+            memory: 170Mi
+          requests:
+            cpu: 100m
+            memory: 70Mi
+        args: [ '-conf', '/etc/coredns/Corefile' ]
+        volumeMounts:
+        - name: config-volume
+          mountPath: /etc/coredns
+          readOnly: true
+        ports:
+        - containerPort: 53
+          name: dns
+          protocol: UDP
+        - containerPort: 53
+          name: dns-tcp
+          protocol: TCP
+        - containerPort: 9153
+          name: metrics
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 60
+          timeoutSeconds: 5
+          successThreshold: 1
+          failureThreshold: 5
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add:
+            - NET_BIND_SERVICE
+            drop:
+            - all
+          readOnlyRootFilesystem: true
+      dnsPolicy: Default
+      volumes:
+        - name: config-volume
+          configMap:
+            name: coredns
+            items:
+            - key: Corefile
+              path: Corefile
+---
 apiVersion: v1
 kind: Service
 metadata:
   name: kube-dns
   namespace: kube-system
+  annotations:
+    prometheus.io/port: '9153'
+    prometheus.io/scrape: 'true'
   labels:
     k8s-app: kube-dns
     kubernetes.io/cluster-service: 'true'
-    kubernetes.io/name: 'KubeDNS'
+    addonmanager.kubernetes.io/mode: Reconcile
+    kubernetes.io/name: CoreDNS
 spec:
   selector:
     k8s-app: kube-dns
-  clusterIP: 10.3.0.10
+  clusterIP: '10.3.0.10'
   ports:
   - name: dns
     port: 53
@@ -24,105 +189,6 @@ spec:
   - name: dns-tcp
     port: 53
     protocol: TCP
----
-apiVersion: v1
-kind: ReplicationController
-metadata:
-  name: kube-dns-v11
-  namespace: kube-system
-  labels:
-    k8s-app: kube-dns
-    version: v11
-    kubernetes.io/cluster-service: 'true'
-spec:
-  replicas: 1
-  selector:
-    k8s-app: kube-dns
-    version: v11
-  template:
-    metadata:
-      labels:
-        k8s-app: kube-dns
-        version: v11
-        kubernetes.io/cluster-service: 'true'
-    spec:
-            containers:
-            - name: etcd
-              image: gcr.io/google_containers/etcd:2.0.9
-              resources:
-                limits:
-                  cpu: 100m
-                  memory: 50Mi
-              command:
-              - /usr/local/bin/etcd
-              - -data-dir
-              - /var/etcd/data
-              - -listen-client-urls
-              - http://127.0.0.1:2379,http://127.0.0.1:4001
-              - -advertise-client-urls
-              - http://127.0.0.1:2379,http://127.0.0.1:4001
-              - -initial-cluster-token
-              - skydns-etcd
-              volumeMounts:
-              - name: etcd-storage
-                mountPath: /var/etcd/data
-            - name: kube2sky
-              image: gcr.io/google_containers/kube2sky:1.11
-              resources:
-                limits:
-                  cpu: 100m
-                  memory: 50Mi
-              args:
-              # command = "/kube2sky"
-              - -domain=cluster.local
-            - name: skydns
-              image: gcr.io/google_containers/skydns:2015-03-11-001
-              resources:
-                limits:
-                  cpu: 100m
-                  memory: 50Mi
-              args:
-              # command = "/skydns"
-              - -machines=http://localhost:4001
-              - -addr=0.0.0.0:53
-              - -domain=cluster.local.
-              ports:
-              - containerPort: 53
-                name: dns
-                protocol: UDP
-              - containerPort: 53
-                name: dns-tcp
-                protocol: TCP
-              livenessProbe:
-                httpGet:
-                  path: /healthz
-                  port: 8080
-                  scheme: HTTP
-                initialDelaySeconds: 30
-                timeoutSeconds: 5
-              readinessProbe:
-                httpGet:
-                  path: /healthz
-                  port: 8080
-                  scheme: HTTP
-                initialDelaySeconds: 1
-                timeoutSeconds: 5
-            - name: healthz
-              image: gcr.io/google_containers/exechealthz:1.0
-              resources:
-                limits:
-                  cpu: 10m
-                  memory: 20Mi
-              args:
-              - -cmd=nslookup kubernetes.default.svc.cluster.local localhost >/dev/null
-              - -port=8080
-              ports:
-              - containerPort: 8080
-                protocol: TCP
-            volumes:
-            - name: etcd-storage
-              emptyDir: {}
-            dnsPolicy: Default
 EOF"
 
 sudo mkdir -p ${KUBERNETES_MANIFESTS_DIR}


### PR DESCRIPTION
Use coredns instead of skydns as a kube-dns server.