### PR TITLE
Install prometheus-operator properly

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -70,14 +70,14 @@ func kubeConfigFor(k *model.Kube) (clientcmddapi.Config, error) {
 	return clientcmddapi.Config{
 		AuthInfos: map[string]*clientcmddapi.AuthInfo{
 			k.Auth.Username: {
-				Token: k.Auth.Token,
+				Token:                 k.Auth.Token,
 				ClientCertificateData: []byte(k.Auth.Cert),
 				ClientKeyData:         []byte(k.Auth.Key),
 			},
 		},
 		Clusters: map[string]*clientcmddapi.Cluster{
 			k.Auth.Username: {
-				Server: apiAddr,
+				Server:                   apiAddr,
 				CertificateAuthorityData: []byte(k.Auth.CACert),
 			},
 		},

--- a/pkg/kube/handler.go
+++ b/pkg/kube/handler.go
@@ -2,11 +2,13 @@ package kube
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -14,7 +16,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"gopkg.in/asaskevich/govalidator.v8"
 
-	"crypto/tls"
 	"github.com/supergiant/supergiant/pkg/clouds"
 	"github.com/supergiant/supergiant/pkg/message"
 	"github.com/supergiant/supergiant/pkg/model"
@@ -26,7 +27,6 @@ import (
 	"github.com/supergiant/supergiant/pkg/workflows"
 	"github.com/supergiant/supergiant/pkg/workflows/statuses"
 	"github.com/supergiant/supergiant/pkg/workflows/steps"
-	"strings"
 )
 
 type accountGetter interface {

--- a/pkg/workflows/steps/config.go
+++ b/pkg/workflows/steps/config.go
@@ -108,6 +108,7 @@ type PostStartConfig struct {
 
 type TillerConfig struct {
 	HelmVersion     string `json:"helmVersion"`
+	RBACEnabled     bool   `json:"rbacEnabled"`
 	OperatingSystem string `json:"operatingSystem"`
 	Arch            string `json:"arch"`
 }

--- a/pkg/workflows/steps/prometheus/prometheus_test.go
+++ b/pkg/workflows/steps/prometheus/prometheus_test.go
@@ -72,10 +72,6 @@ func TestPrometheusRBACDisbled(t *testing.T) {
 	if !strings.Contains(output.String(), "prometheus-operator") {
 		t.Errorf("not found %s in %s", "prometheus-operator", output.String())
 	}
-
-	if !strings.Contains(output.String(), "sudo kubectl apply -f cluster-roles.yaml --validate=false") {
-		t.Errorf("command for creating roles not found in %s", output.String())
-	}
 }
 
 func TestPrometheusRBACEnabled(t *testing.T) {

--- a/pkg/workflows/steps/tiller/tiller_test.go
+++ b/pkg/workflows/steps/tiller/tiller_test.go
@@ -32,6 +32,7 @@ func (f *fakeRunner) Run(command *runner.Command) error {
 
 func TestInstallTiller(t *testing.T) {
 	helmVersion := "helm-v2.8.2"
+	rbacEnabled := false
 	operatingSystem := "linux"
 	arch := "amd64"
 	r := &fakeRunner{}
@@ -56,9 +57,10 @@ func TestInstallTiller(t *testing.T) {
 
 	cfg := &steps.Config{
 		TillerConfig: steps.TillerConfig{
-			helmVersion,
-			operatingSystem,
-			arch,
+			HelmVersion:     helmVersion,
+			RBACEnabled:     rbacEnabled,
+			OperatingSystem: operatingSystem,
+			Arch:            arch,
 		},
 		Runner: r,
 	}
@@ -66,7 +68,7 @@ func TestInstallTiller(t *testing.T) {
 	err = j.Run(context.Background(), output, cfg)
 
 	if err != nil {
-		t.Errorf("Unpexpected error while  provision node %v", err)
+		t.Errorf("Unpexpected error while  provision node: %v", err)
 	}
 
 	if !strings.Contains(output.String(), helmVersion) {

--- a/templates/prometheus.sh.tpl
+++ b/templates/prometheus.sh.tpl
@@ -1,6 +1,8 @@
-{{if not .RBACEnabled }}
-wget https://raw.githubusercontent.com/kubernetes/kubernetes/release-1.12/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
-sudo kubectl apply -f cluster-roles.yaml --validate=false
-{{end}}
-sleep 60
-sudo /opt/bin/helm install stable/prometheus-operator
+# prometheus-operator hac rbac enabled by default so set
+# it explicitly
+sudo /opt/bin/helm install stable/prometheus-operator \
+    --name=prometheus-operator \
+    --set global.rbac.create={{ .RBACEnabled }} \
+    --set grafana.rbac.create={{ .RBACEnabled }} \
+    --set kube-state-metrics.rbac.create={{ .RBACEnabled }} \
+    --set prometheus-node-exporter.rbac.create={{ .RBACEnabled }}

--- a/templates/tiller.tpl
+++ b/templates/tiller.tpl
@@ -5,14 +5,9 @@ sudo cp /tmp/linux-amd64/helm /opt/bin/helm
 sudo chmod +x /opt/bin/helm
 
 sudo kubectl create serviceaccount -n kube-system tiller
+{{if .RBACEnabled }}
 sudo kubectl create clusterrolebinding tiller-binding --clusterrole=cluster-admin --serviceaccount kube-system:tiller
-sudo /opt/bin/helm init --service-account tiller
+{{ end }}
 
-until $([ $(sudo kubectl get pods --namespace=kube-system|grep tiller|grep Running|wc -l) -eq 1 ]); do printf '.'; sleep 5; done
-TILLER_PORT=44135
-TILLER_POD=$(sudo kubectl get pods --namespace=kube-system|grep tiller|awk '{print $1}')
-TILLER_IP=$(sudo kubectl describe pod $TILLER_POD -n kube-system|grep IP| awk '{print $2}')
-until $(curl --output /dev/null --silent --head --fail http://$TILLER_IP:$TILLER_PORT/readiness); do
-    printf '.'
-    sleep 5
-done
+echo "Install tiller and wait for it to be ready"
+sudo /opt/bin/helm init --service-account tiller --wait


### PR DESCRIPTION
With https://github.com/supergiant/supergiant/pull/715 rbac roles are installed for clusters with disabled RBAC. Some conformance tests fail on this:
```
Nov 5 14:09:15.657: INFO: Found ClusterRoles; assuming RBAC is enabled.
```

Set rbac values for `prometheus-operator` explicitly to avoid it. 