### PR TITLE
Use less severe log level when handle SIGTERM or SIGINT

### DIFF
--- a/pkg/controlplane/server.go
+++ b/pkg/controlplane/server.go
@@ -54,7 +54,7 @@ type Server struct {
 func (srv *Server) Start() {
 	err := srv.server.ListenAndServe()
 	if err != nil {
-		logrus.Fatal(err)
+		logrus.Error(err)
 	}
 }
 
@@ -64,7 +64,7 @@ func (srv *Server) Shutdown() {
 	err := srv.server.Shutdown(ctx)
 
 	if err != nil {
-		logrus.Fatal(err)
+		logrus.Error(err)
 	}
 }
 


### PR DESCRIPTION
User can get confused by `exit 1` after Shutdown method 
of http server finishes.