### PR TITLE
Update log formatter

### DIFF
--- a/pkg/controlplane/server.go
+++ b/pkg/controlplane/server.go
@@ -74,7 +74,6 @@ type Config struct {
 	Port         int
 	Addr         string
 	EtcdUrl      string
-	LogLevel     string
 	TemplatesDir string
 
 	ReadTimeout  time.Duration
@@ -87,7 +86,6 @@ func New(cfg *Config) (*Server, error) {
 		return nil, err
 	}
 
-	configureLogging(cfg)
 	r, err := configureApplication(cfg)
 	if err != nil {
 		return nil, err
@@ -267,16 +265,6 @@ func configureApplication(cfg *Config) (*mux.Router, error) {
 	protectedAPI.Use(authMiddleware.AuthMiddleware, api.ContentTypeJSON)
 
 	return router, nil
-}
-
-func configureLogging(cfg *Config) {
-	l, err := logrus.ParseLevel(cfg.LogLevel)
-	if err != nil {
-		logrus.Warnf("incorrect logging level %s provided, setting INFO as default...", l)
-		logrus.SetLevel(logrus.InfoLevel)
-		return
-	}
-	logrus.SetLevel(l)
 }
 
 func ensureHelmRepositories(svc sghelm.Servicer) {


### PR DESCRIPTION
* add json formatter for logs;
* change log timestamp format to RFC3339.

```
$ ./supergiant -h
...
  -log-format string
        logging format [txt json] (default "txt")
...

$ ./supergiant ...
INFO[2018-11-14T23:05:22+02:00] connecting to the ETCD...                    
INFO[2018-11-14T23:05:22+02:00] supergiant is starting on port 8080 

$ ./supergiant -log-format=json ...
{"level":"info","msg":"connecting to the ETCD...","time":"2018-11-14T23:04:58+02:00"}
{"level":"info","msg":"supergiant is starting on port 8080","time":"2018-11-14T23:04:58+02:00"}
```

Fixes https://github.com/supergiant/supergiant/issues/859