### PR TITLE
Add exponential back-off to wait for public ip addr

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -78,7 +78,7 @@ func adminKubeConfig(k *model.Kube) (clientcmddapi.Config, error) {
 		},
 		Clusters: map[string]*clientcmddapi.Cluster{
 			k.Name: {
-				Server:                   apiAddr,
+				Server: apiAddr,
 				CertificateAuthorityData: []byte(k.Auth.CACert),
 			},
 		},


### PR DESCRIPTION
Sometimes default timeout and constant sleep time between attempts are not enough to
spin up AWS node. Add exponential back-off for timeout and increase initial wait time.

Closes #894 