### PR TITLE
Fail fast on template not found

### DIFF
--- a/pkg/templatemanager/template_manager.go
+++ b/pkg/templatemanager/template_manager.go
@@ -5,9 +5,10 @@ import (
 	"os"
 	"path"
 	"strings"
-	"text/template"
-	"github.com/supergiant/supergiant/pkg/sgerrors"
 	"sync"
+	"text/template"
+
+	"github.com/supergiant/supergiant/pkg/sgerrors"
 )
 
 var (

--- a/pkg/templatemanager/template_manager_test.go
+++ b/pkg/templatemanager/template_manager_test.go
@@ -6,6 +6,20 @@ import (
 	"text/template"
 )
 
+
+func TestGetTemplate(t *testing.T) {
+	testKey := "testGetKey"
+	testValue := &template.Template{}
+	templateMap[testKey] = testValue
+
+	_, err := GetTemplate("testGetKey")
+
+	if sgerrors.IsNotFound(err) {
+		t.Errorf("Template %s not found", testKey)
+	}
+}
+
+
 func TestGetTemplateNotFound(t *testing.T) {
 	_, err := GetTemplate("not_found.sh.tpl")
 
@@ -28,7 +42,7 @@ func TestDeleteTemplate(t *testing.T) {
 }
 
 func TestSetTemplate(t *testing.T) {
-	testKey := "testDeleteKey"
+	testKey := "testSetKey"
 	testValue := &template.Template{}
 	templateMap[testKey] = testValue
 

--- a/pkg/templatemanager/template_manager_test.go
+++ b/pkg/templatemanager/template_manager_test.go
@@ -3,6 +3,7 @@ package templatemanager
 import (
 	"testing"
 	"github.com/supergiant/supergiant/pkg/sgerrors"
+	"text/template"
 )
 
 func TestGetTemplateNotFound(t *testing.T) {
@@ -10,5 +11,30 @@ func TestGetTemplateNotFound(t *testing.T) {
 
 	if !sgerrors.IsNotFound(err) {
 		t.Errorf("Wrong error expected %v actual %v", sgerrors.ErrNotFound, err)
+	}
+}
+
+
+func TestDeleteTemplate(t *testing.T) {
+	testKey := "testDeleteKey"
+	testValue := &template.Template{}
+	templateMap[testKey] = testValue
+
+	DeleteTemplate(testKey)
+
+	if _, ok := templateMap[testKey]; ok {
+		t.Errorf("key %s must not be in templateMap %v", testKey, templateMap)
+	}
+}
+
+func TestSetTemplate(t *testing.T) {
+	testKey := "testDeleteKey"
+	testValue := &template.Template{}
+	templateMap[testKey] = testValue
+
+	SetTemplate(testKey, testValue)
+
+	if _, ok := templateMap[testKey]; !ok {
+		t.Errorf("key %s must not in templateMap %v", testKey, templateMap)
 	}
 }

--- a/pkg/templatemanager/template_manager_test.go
+++ b/pkg/templatemanager/template_manager_test.go
@@ -1,0 +1,14 @@
+package templatemanager
+
+import (
+	"testing"
+	"github.com/supergiant/supergiant/pkg/sgerrors"
+)
+
+func TestGetTemplateNotFound(t *testing.T) {
+	_, err := GetTemplate("not_found.sh.tpl")
+
+	if !sgerrors.IsNotFound(err) {
+		t.Errorf("Wrong error expected %v actual %v", sgerrors.ErrNotFound, err)
+	}
+}

--- a/pkg/workflows/steps/authorizedKeys/add_authorized_key.go
+++ b/pkg/workflows/steps/authorizedKeys/add_authorized_key.go
@@ -10,6 +10,7 @@ import (
 	"github.com/supergiant/supergiant/pkg/templatemanager"
 	"github.com/supergiant/supergiant/pkg/util"
 	"github.com/supergiant/supergiant/pkg/workflows/steps"
+	"fmt"
 )
 
 type Step struct {
@@ -19,7 +20,12 @@ type Step struct {
 const StepName = "add_authorized_keys"
 
 func Init() {
-	steps.RegisterStep(StepName, NewAddAuthorizedKeys(templatemanager.GetTemplate(StepName)))
+	tpl, err := templatemanager.GetTemplate(StepName)
+
+	if err != nil {
+		panic(fmt.Sprintf("template %s not found", StepName))
+	}
+	steps.RegisterStep(StepName, NewAddAuthorizedKeys(tpl))
 }
 
 func NewAddAuthorizedKeys(script *template.Template) *Step {

--- a/pkg/workflows/steps/certificates/certificates.go
+++ b/pkg/workflows/steps/certificates/certificates.go
@@ -9,6 +9,7 @@ import (
 
 	tm "github.com/supergiant/supergiant/pkg/templatemanager"
 	"github.com/supergiant/supergiant/pkg/workflows/steps"
+	"fmt"
 )
 
 const StepName = "certificates"
@@ -22,7 +23,13 @@ func (s *Step) Rollback(context.Context, io.Writer, *steps.Config) error {
 }
 
 func Init() {
-	steps.RegisterStep(StepName, New(tm.GetTemplate(StepName)))
+	tpl, err := tm.GetTemplate(StepName)
+
+	if err != nil {
+		panic(fmt.Sprintf("template %s not found", StepName))
+	}
+
+	steps.RegisterStep(StepName, New(tpl))
 }
 
 func New(script *template.Template) *Step {

--- a/pkg/workflows/steps/certificates/certificates_test.go
+++ b/pkg/workflows/steps/certificates/certificates_test.go
@@ -49,7 +49,7 @@ func TestWriteCertificates(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tpl := templatemanager.GetTemplate(StepName)
+	tpl, _ := templatemanager.GetTemplate(StepName)
 
 	if tpl == nil {
 		t.Fatal("template not found")
@@ -236,9 +236,27 @@ func TestNew(t *testing.T) {
 }
 
 func TestInit(t *testing.T) {
+	templatemanager.SetTemplate(StepName, &template.Template{})
 	Init()
+	templatemanager.DeleteTemplate(StepName)
 
 	s := steps.GetStep(StepName)
+
+	if s == nil {
+		t.Error("Step not found")
+	}
+}
+
+func TestInitPanic(t *testing.T) {
+	defer func(){
+		if r := recover(); r == nil {
+			t.Errorf("recover output must not be nil")
+		}
+	}()
+
+	Init()
+
+	s := steps.GetStep("not_found.sh.tpl")
 
 	if s == nil {
 		t.Error("Step not found")

--- a/pkg/workflows/steps/clustercheck/cluster_check.go
+++ b/pkg/workflows/steps/clustercheck/cluster_check.go
@@ -10,6 +10,7 @@ import (
 	tm "github.com/supergiant/supergiant/pkg/templatemanager"
 	"github.com/supergiant/supergiant/pkg/workflows/steps"
 	"github.com/supergiant/supergiant/pkg/workflows/steps/kubelet"
+	"fmt"
 )
 
 const StepName = "clustercheck"
@@ -19,7 +20,14 @@ type Step struct {
 }
 
 func Init() {
-	steps.RegisterStep(StepName, New(tm.GetTemplate(StepName)))
+	tpl, err := tm.GetTemplate(StepName)
+
+	if err != nil {
+		panic(fmt.Sprintf("template %s not found", StepName))
+	}
+
+
+	steps.RegisterStep(StepName, New(tpl))
 }
 
 func New(script *template.Template) *Step {

--- a/pkg/workflows/steps/clustercheck/cluster_check_test.go
+++ b/pkg/workflows/steps/clustercheck/cluster_check_test.go
@@ -45,7 +45,7 @@ func TestClusterCheck(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tpl := templatemanager.GetTemplate(StepName)
+	tpl, _ := templatemanager.GetTemplate(StepName)
 
 	if tpl == nil {
 		t.Fatal("template not found")
@@ -144,7 +144,9 @@ func TestNew(t *testing.T) {
 }
 
 func TestInit(t *testing.T) {
+	templatemanager.SetTemplate(StepName, &template.Template{})
 	Init()
+	templatemanager.DeleteTemplate(StepName)
 
 	s := steps.GetStep(StepName)
 
@@ -152,3 +154,20 @@ func TestInit(t *testing.T) {
 		t.Error("Step not found")
 	}
 }
+
+func TestInitPanic(t *testing.T) {
+	defer func(){
+		if r := recover(); r == nil {
+			t.Errorf("recover output must not be nil")
+		}
+	}()
+
+	Init()
+
+	s := steps.GetStep("not_found.sh.tpl")
+
+	if s == nil {
+		t.Error("Step not found")
+	}
+}
+

--- a/pkg/workflows/steps/cni/cni.go
+++ b/pkg/workflows/steps/cni/cni.go
@@ -9,6 +9,7 @@ import (
 
 	tm "github.com/supergiant/supergiant/pkg/templatemanager"
 	"github.com/supergiant/supergiant/pkg/workflows/steps"
+	"fmt"
 )
 
 const StepName = "cni"
@@ -22,7 +23,13 @@ func (s *Step) Rollback(context.Context, io.Writer, *steps.Config) error {
 }
 
 func Init() {
-	steps.RegisterStep(StepName, New(tm.GetTemplate(StepName)))
+	tpl, err := tm.GetTemplate(StepName)
+
+	if err != nil {
+		panic(fmt.Sprintf("template %s not found", StepName))
+	}
+
+	steps.RegisterStep(StepName, New(tpl))
 }
 
 func New(script *template.Template) *Step {

--- a/pkg/workflows/steps/cni/cni_test.go
+++ b/pkg/workflows/steps/cni/cni_test.go
@@ -43,7 +43,7 @@ func TestCNI(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tpl := templatemanager.GetTemplate(StepName)
+	tpl, _ := templatemanager.GetTemplate(StepName)
 
 	if tpl == nil {
 		t.Fatal("template not found")

--- a/pkg/workflows/steps/docker/docker.go
+++ b/pkg/workflows/steps/docker/docker.go
@@ -9,6 +9,7 @@ import (
 
 	tm "github.com/supergiant/supergiant/pkg/templatemanager"
 	"github.com/supergiant/supergiant/pkg/workflows/steps"
+	"fmt"
 )
 
 const StepName = "docker"
@@ -18,7 +19,13 @@ type Step struct {
 }
 
 func Init() {
-	steps.RegisterStep(StepName, New(tm.GetTemplate(StepName)))
+	tpl, err := tm.GetTemplate(StepName)
+
+	if err != nil {
+		panic(fmt.Sprintf("template %s not found", StepName))
+	}
+
+	steps.RegisterStep(StepName, New(tpl))
 }
 
 func New(tpl *template.Template) *Step {

--- a/pkg/workflows/steps/docker/docker_test.go
+++ b/pkg/workflows/steps/docker/docker_test.go
@@ -40,7 +40,7 @@ func TestInstallDocker(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tpl := templatemanager.GetTemplate(StepName)
+	tpl, _ := templatemanager.GetTemplate(StepName)
 
 	if tpl == nil {
 		t.Fatal("template not found")
@@ -136,9 +136,27 @@ func TestNew(t *testing.T) {
 }
 
 func TestInit(t *testing.T) {
+	templatemanager.SetTemplate(StepName, &template.Template{})
 	Init()
+	templatemanager.DeleteTemplate(StepName)
 
 	s := steps.GetStep(StepName)
+
+	if s == nil {
+		t.Error("Step not found")
+	}
+}
+
+func TestInitPanic(t *testing.T) {
+	defer func(){
+		if r := recover(); r == nil {
+			t.Errorf("recover output must not be nil")
+		}
+	}()
+
+	Init()
+
+	s := steps.GetStep("not_found.sh.tpl")
 
 	if s == nil {
 		t.Error("Step not found")

--- a/pkg/workflows/steps/downloadk8sbinary/download_k8s_binary.go
+++ b/pkg/workflows/steps/downloadk8sbinary/download_k8s_binary.go
@@ -9,6 +9,7 @@ import (
 
 	tm "github.com/supergiant/supergiant/pkg/templatemanager"
 	"github.com/supergiant/supergiant/pkg/workflows/steps"
+	"fmt"
 )
 
 const StepName = "download_kubernetes_binary"
@@ -18,7 +19,13 @@ type Step struct {
 }
 
 func Init() {
-	steps.RegisterStep(StepName, New(tm.GetTemplate(StepName)))
+	tpl, err := tm.GetTemplate(StepName)
+
+	if err != nil {
+		panic(fmt.Sprintf("get template error %v %s", err, StepName))
+	}
+
+	steps.RegisterStep(StepName, New(tpl))
 }
 
 func New(tpl *template.Template) *Step {

--- a/pkg/workflows/steps/downloadk8sbinary/download_k8s_binary_test.go
+++ b/pkg/workflows/steps/downloadk8sbinary/download_k8s_binary_test.go
@@ -22,7 +22,7 @@ func TestDownloadK8SBinary(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tpl := templatemanager.GetTemplate(StepName)
+	tpl, _ := templatemanager.GetTemplate(StepName)
 
 	if tpl == nil {
 		t.Fatal("template not found")
@@ -123,9 +123,27 @@ func TestNew(t *testing.T) {
 }
 
 func TestInit(t *testing.T) {
+	templatemanager.SetTemplate(StepName, &template.Template{})
 	Init()
+	templatemanager.DeleteTemplate(StepName)
 
 	s := steps.GetStep(StepName)
+
+	if s == nil {
+		t.Error("Step not found")
+	}
+}
+
+func TestInitPanic(t *testing.T) {
+	defer func(){
+		if r := recover(); r == nil {
+			t.Errorf("recover output must not be nil")
+		}
+	}()
+
+	Init()
+
+	s := steps.GetStep("not_found.sh.tpl")
 
 	if s == nil {
 		t.Error("Step not found")

--- a/pkg/workflows/steps/etcd/etcd.go
+++ b/pkg/workflows/steps/etcd/etcd.go
@@ -10,6 +10,7 @@ import (
 	tm "github.com/supergiant/supergiant/pkg/templatemanager"
 	"github.com/supergiant/supergiant/pkg/workflows/steps"
 	"github.com/supergiant/supergiant/pkg/workflows/steps/docker"
+	"fmt"
 )
 
 const StepName = "etcd"
@@ -19,7 +20,13 @@ type Step struct {
 }
 
 func Init() {
-	steps.RegisterStep(StepName, New(tm.GetTemplate(StepName)))
+	tpl, err := tm.GetTemplate(StepName)
+
+	if err != nil {
+		panic(fmt.Sprintf("template %s not found", StepName))
+	}
+
+	steps.RegisterStep(StepName, New(tpl))
 }
 
 func New(tpl *template.Template) *Step {

--- a/pkg/workflows/steps/etcd/etcd_test.go
+++ b/pkg/workflows/steps/etcd/etcd_test.go
@@ -40,7 +40,7 @@ func TestInstallEtcD(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tpl := templatemanager.GetTemplate(StepName)
+	tpl, _ := templatemanager.GetTemplate(StepName)
 
 	if tpl == nil {
 		t.Fatal("template not found")
@@ -116,7 +116,7 @@ func TestInstallEtcdTimeout(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tpl := templatemanager.GetTemplate(StepName)
+	tpl, _ := templatemanager.GetTemplate(StepName)
 
 	if tpl == nil {
 		t.Fatal("template not found")
@@ -215,9 +215,27 @@ func TestNew(t *testing.T) {
 }
 
 func TestInit(t *testing.T) {
+	templatemanager.SetTemplate(StepName, &template.Template{})
 	Init()
+	templatemanager.DeleteTemplate(StepName)
 
 	s := steps.GetStep(StepName)
+
+	if s == nil {
+		t.Error("Step not found")
+	}
+}
+
+func TestInitPanic(t *testing.T) {
+	defer func(){
+		if r := recover(); r == nil {
+			t.Errorf("recover output must not be nil")
+		}
+	}()
+
+	Init()
+
+	s := steps.GetStep("not_found.sh.tpl")
 
 	if s == nil {
 		t.Error("Step not found")

--- a/pkg/workflows/steps/flannel/flannel.go
+++ b/pkg/workflows/steps/flannel/flannel.go
@@ -11,6 +11,7 @@ import (
 	"github.com/supergiant/supergiant/pkg/workflows/steps"
 	"github.com/supergiant/supergiant/pkg/workflows/steps/etcd"
 	"github.com/supergiant/supergiant/pkg/workflows/steps/network"
+	"fmt"
 )
 
 const StepName = "flannel"
@@ -20,7 +21,13 @@ type Step struct {
 }
 
 func Init() {
-	steps.RegisterStep(StepName, New(tm.GetTemplate(StepName)))
+	tpl, err := tm.GetTemplate(StepName)
+
+	if err != nil {
+		panic(fmt.Sprintf("template %s not found", StepName))
+	}
+
+	steps.RegisterStep(StepName, New(tpl))
 }
 
 func New(tpl *template.Template) *Step {

--- a/pkg/workflows/steps/flannel/flannel_test.go
+++ b/pkg/workflows/steps/flannel/flannel_test.go
@@ -40,7 +40,7 @@ func TestFlannelJob_InstallFlannel(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tpl := templatemanager.GetTemplate(StepName)
+	tpl, _ := templatemanager.GetTemplate(StepName)
 
 	if tpl == nil {
 		t.Fatal("template not found")
@@ -184,9 +184,27 @@ func TestNew(t *testing.T) {
 }
 
 func TestInit(t *testing.T) {
+	templatemanager.SetTemplate(StepName, &template.Template{})
 	Init()
+	templatemanager.DeleteTemplate(StepName)
 
 	s := steps.GetStep(StepName)
+
+	if s == nil {
+		t.Error("Step not found")
+	}
+}
+
+func TestInitPanic(t *testing.T) {
+	defer func(){
+		if r := recover(); r == nil {
+			t.Errorf("recover output must not be nil")
+		}
+	}()
+
+	Init()
+
+	s := steps.GetStep("not_found.sh.tpl")
 
 	if s == nil {
 		t.Error("Step not found")

--- a/pkg/workflows/steps/kubelet/kubelet.go
+++ b/pkg/workflows/steps/kubelet/kubelet.go
@@ -11,6 +11,7 @@ import (
 	"github.com/supergiant/supergiant/pkg/workflows/steps"
 	"github.com/supergiant/supergiant/pkg/workflows/steps/docker"
 	"github.com/supergiant/supergiant/pkg/workflows/steps/manifest"
+	"fmt"
 )
 
 const StepName = "kubelet"
@@ -20,7 +21,13 @@ type Step struct {
 }
 
 func Init() {
-	steps.RegisterStep(StepName, New(tm.GetTemplate(StepName)))
+	tpl, err := tm.GetTemplate(StepName)
+
+	if err != nil {
+		panic(fmt.Sprintf("template %s not found", StepName))
+	}
+
+	steps.RegisterStep(StepName, New(tpl))
 }
 
 func New(script *template.Template) *Step {

--- a/pkg/workflows/steps/kubelet/kubelet_test.go
+++ b/pkg/workflows/steps/kubelet/kubelet_test.go
@@ -42,7 +42,7 @@ func TestStartKubelet(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tpl := templatemanager.GetTemplate(StepName)
+	tpl, _ := templatemanager.GetTemplate(StepName)
 
 	if tpl == nil {
 		t.Fatal("template not found")
@@ -135,9 +135,27 @@ func TestNew(t *testing.T) {
 }
 
 func TestInit(t *testing.T) {
+	templatemanager.SetTemplate(StepName, &template.Template{})
 	Init()
+	templatemanager.DeleteTemplate(StepName)
 
 	s := steps.GetStep(StepName)
+
+	if s == nil {
+		t.Error("Step not found")
+	}
+}
+
+func TestInitPanic(t *testing.T) {
+	defer func(){
+		if r := recover(); r == nil {
+			t.Errorf("recover output must not be nil")
+		}
+	}()
+
+	Init()
+
+	s := steps.GetStep("not_found.sh.tpl")
 
 	if s == nil {
 		t.Error("Step not found")

--- a/pkg/workflows/steps/manifest/manifest.go
+++ b/pkg/workflows/steps/manifest/manifest.go
@@ -10,6 +10,7 @@ import (
 	tm "github.com/supergiant/supergiant/pkg/templatemanager"
 	"github.com/supergiant/supergiant/pkg/workflows/steps"
 	"github.com/supergiant/supergiant/pkg/workflows/steps/certificates"
+	"fmt"
 )
 
 const StepName = "manifest"
@@ -19,7 +20,13 @@ type Step struct {
 }
 
 func Init() {
-	steps.RegisterStep(StepName, New(tm.GetTemplate(StepName)))
+	tpl, err := tm.GetTemplate(StepName)
+
+	if err != nil {
+		panic(fmt.Sprintf("template %s not found", StepName))
+	}
+
+	steps.RegisterStep(StepName, New(tpl))
 }
 
 func New(script *template.Template) *Step {

--- a/pkg/workflows/steps/manifest/manifest_test.go
+++ b/pkg/workflows/steps/manifest/manifest_test.go
@@ -48,7 +48,7 @@ func TestWriteManifestMaster(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tpl := templatemanager.GetTemplate(StepName)
+	tpl, _ := templatemanager.GetTemplate(StepName)
 
 	if tpl == nil {
 		t.Fatal("template not found")
@@ -125,7 +125,7 @@ func TestWriteManifestNode(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tpl := templatemanager.GetTemplate(StepName)
+	tpl, _ := templatemanager.GetTemplate(StepName)
 
 	if tpl == nil {
 		t.Fatal("template not found")
@@ -240,9 +240,27 @@ func TestNew(t *testing.T) {
 }
 
 func TestInit(t *testing.T) {
+	templatemanager.SetTemplate(StepName, &template.Template{})
 	Init()
+	templatemanager.DeleteTemplate(StepName)
 
 	s := steps.GetStep(StepName)
+
+	if s == nil {
+		t.Error("Step not found")
+	}
+}
+
+func TestInitPanic(t *testing.T) {
+	defer func(){
+		if r := recover(); r == nil {
+			t.Errorf("recover output must not be nil")
+		}
+	}()
+
+	Init()
+
+	s := steps.GetStep("not_found.sh.tpl")
 
 	if s == nil {
 		t.Error("Step not found")

--- a/pkg/workflows/steps/network/network.go
+++ b/pkg/workflows/steps/network/network.go
@@ -10,6 +10,7 @@ import (
 	tm "github.com/supergiant/supergiant/pkg/templatemanager"
 	"github.com/supergiant/supergiant/pkg/workflows/steps"
 	"github.com/supergiant/supergiant/pkg/workflows/steps/etcd"
+	"fmt"
 )
 
 const StepName = "network"
@@ -19,7 +20,13 @@ type Step struct {
 }
 
 func Init() {
-	steps.RegisterStep(StepName, New(tm.GetTemplate(StepName)))
+	tpl, err := tm.GetTemplate(StepName)
+
+	if err != nil {
+		panic(fmt.Sprintf("template %s not found", StepName))
+	}
+
+	steps.RegisterStep(StepName, New(tpl))
 }
 
 func New(tpl *template.Template) *Step {

--- a/pkg/workflows/steps/network/network_test.go
+++ b/pkg/workflows/steps/network/network_test.go
@@ -39,7 +39,7 @@ func TestNetworkConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tpl := templatemanager.GetTemplate(StepName)
+	tpl,_ := templatemanager.GetTemplate(StepName)
 
 	if tpl == nil {
 		t.Fatal("template not found")
@@ -207,9 +207,27 @@ func TestNew(t *testing.T) {
 }
 
 func TestInit(t *testing.T) {
+	templatemanager.SetTemplate(StepName, &template.Template{})
 	Init()
+	templatemanager.DeleteTemplate(StepName)
 
 	s := steps.GetStep(StepName)
+
+	if s == nil {
+		t.Error("Step not found")
+	}
+}
+
+func TestInitPanic(t *testing.T) {
+	defer func(){
+		if r := recover(); r == nil {
+			t.Errorf("recover output must not be nil")
+		}
+	}()
+
+	Init()
+
+	s := steps.GetStep("not_found.sh.tpl")
 
 	if s == nil {
 		t.Error("Step not found")

--- a/pkg/workflows/steps/poststart/post_start.go
+++ b/pkg/workflows/steps/poststart/post_start.go
@@ -12,6 +12,7 @@ import (
 	tm "github.com/supergiant/supergiant/pkg/templatemanager"
 	"github.com/supergiant/supergiant/pkg/workflows/steps"
 	"github.com/supergiant/supergiant/pkg/workflows/steps/kubelet"
+	"fmt"
 )
 
 const StepName = "poststart"
@@ -21,7 +22,13 @@ type Step struct {
 }
 
 func Init() {
-	steps.RegisterStep(StepName, New(tm.GetTemplate(StepName)))
+	tpl, err := tm.GetTemplate(StepName)
+
+	if err != nil {
+		panic(fmt.Sprintf("template %s not found", StepName))
+	}
+
+	steps.RegisterStep(StepName, New(tpl))
 }
 
 func New(script *template.Template) *Step {

--- a/pkg/workflows/steps/poststart/post_start_test.go
+++ b/pkg/workflows/steps/poststart/post_start_test.go
@@ -49,7 +49,7 @@ func TestPostStartMaster(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tpl := templatemanager.GetTemplate(StepName)
+	tpl, _ := templatemanager.GetTemplate(StepName)
 
 	if tpl == nil {
 		t.Fatal("template not found")
@@ -100,7 +100,7 @@ func TestPostStartNode(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tpl := templatemanager.GetTemplate(StepName)
+	tpl, _ := templatemanager.GetTemplate(StepName)
 
 	if tpl == nil {
 		t.Fatal("template not found")
@@ -242,9 +242,27 @@ func TestNew(t *testing.T) {
 }
 
 func TestInit(t *testing.T) {
+	templatemanager.SetTemplate(StepName, &template.Template{})
 	Init()
+	templatemanager.DeleteTemplate(StepName)
 
 	s := steps.GetStep(StepName)
+
+	if s == nil {
+		t.Error("Step not found")
+	}
+}
+
+func TestInitPanic(t *testing.T) {
+	defer func(){
+		if r := recover(); r == nil {
+			t.Errorf("recover output must not be nil")
+		}
+	}()
+
+	Init()
+
+	s := steps.GetStep("not_found.sh.tpl")
 
 	if s == nil {
 		t.Error("Step not found")

--- a/pkg/workflows/steps/prometheus/prometheus.go
+++ b/pkg/workflows/steps/prometheus/prometheus.go
@@ -9,6 +9,7 @@ import (
 
 	tm "github.com/supergiant/supergiant/pkg/templatemanager"
 	"github.com/supergiant/supergiant/pkg/workflows/steps"
+	"fmt"
 )
 
 const StepName = "prometheus"
@@ -22,7 +23,13 @@ func (s *Step) Rollback(context.Context, io.Writer, *steps.Config) error {
 }
 
 func Init() {
-	steps.RegisterStep(StepName, New(tm.GetTemplate(StepName)))
+	tpl, err := tm.GetTemplate(StepName)
+
+	if err != nil {
+		panic(fmt.Sprintf("template %s not found", StepName))
+	}
+
+	steps.RegisterStep(StepName, New(tpl))
 }
 
 func New(script *template.Template) *Step {

--- a/pkg/workflows/steps/prometheus/prometheus_test.go
+++ b/pkg/workflows/steps/prometheus/prometheus_test.go
@@ -43,7 +43,7 @@ func TestPrometheusRBACDisbled(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tpl := templatemanager.GetTemplate(StepName)
+	tpl, _ := templatemanager.GetTemplate(StepName)
 
 	if tpl == nil {
 		t.Fatal("template not found")
@@ -87,7 +87,7 @@ func TestPrometheusRBACEnabled(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tpl := templatemanager.GetTemplate(StepName)
+	tpl, _ := templatemanager.GetTemplate(StepName)
 
 	if tpl == nil {
 		t.Fatal("template not found")
@@ -185,9 +185,27 @@ func TestNew(t *testing.T) {
 }
 
 func TestInit(t *testing.T) {
+	templatemanager.SetTemplate(StepName, &template.Template{})
 	Init()
+	templatemanager.DeleteTemplate(StepName)
 
 	s := steps.GetStep(StepName)
+
+	if s == nil {
+		t.Error("Step not found")
+	}
+}
+
+func TestInitPanic(t *testing.T) {
+	defer func(){
+		if r := recover(); r == nil {
+			t.Errorf("recover output must not be nil")
+		}
+	}()
+
+	Init()
+
+	s := steps.GetStep("not_found.sh.tpl")
 
 	if s == nil {
 		t.Error("Step not found")

--- a/pkg/workflows/steps/tiller/tiller.go
+++ b/pkg/workflows/steps/tiller/tiller.go
@@ -10,6 +10,7 @@ import (
 	tm "github.com/supergiant/supergiant/pkg/templatemanager"
 	"github.com/supergiant/supergiant/pkg/workflows/steps"
 	"github.com/supergiant/supergiant/pkg/workflows/steps/poststart"
+	"fmt"
 )
 
 const (
@@ -21,7 +22,14 @@ type Step struct {
 }
 
 func Init() {
-	steps.RegisterStep(StepName, New(tm.GetTemplate(StepName)))
+	tpl, err := tm.GetTemplate(StepName)
+
+	if err != nil {
+		panic(fmt.Sprintf("template %s not found", StepName))
+	}
+
+
+	steps.RegisterStep(StepName, New(tpl))
 }
 
 func New(script *template.Template) *Step {

--- a/pkg/workflows/steps/tiller/tiller_test.go
+++ b/pkg/workflows/steps/tiller/tiller_test.go
@@ -43,7 +43,7 @@ func TestInstallTiller(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tpl := templatemanager.GetTemplate(StepName)
+	tpl, _ := templatemanager.GetTemplate(StepName)
 
 	if tpl == nil {
 		t.Fatal("template not found")
@@ -149,9 +149,27 @@ func TestNew(t *testing.T) {
 }
 
 func TestInit(t *testing.T) {
+	templatemanager.SetTemplate(StepName, &template.Template{})
 	Init()
+	templatemanager.DeleteTemplate(StepName)
 
 	s := steps.GetStep(StepName)
+
+	if s == nil {
+		t.Error("Step not found")
+	}
+}
+
+func TestInitPanic(t *testing.T) {
+	defer func(){
+		if r := recover(); r == nil {
+			t.Errorf("recover output must not be nil")
+		}
+	}()
+
+	Init()
+
+	s := steps.GetStep("not_found.sh.tpl")
 
 	if s == nil {
 		t.Error("Step not found")


### PR DESCRIPTION
When one of template needed for cluster provisioning not found we need
to fail with panic on SG start-up. We don't wont let user to pass all cluster
configuration steps and fail during cluster spin up because of nil pointer.

Closes #900 