### PR TITLE
Add custom user to SG

### DIFF
--- a/pkg/account/region_finder.go
+++ b/pkg/account/region_finder.go
@@ -76,6 +76,9 @@ func NewRegionsGetter(account *model.CloudAccount, config *steps.Config) (Region
 	case clouds.DigitalOcean:
 		return NewDOFinder(account)
 	case clouds.AWS:
+		// We need to provide region to AWS even if our
+		// request does not specify region
+		config.AWSConfig.Region = "us-west-1"
 		return NewAWSFinder(account, config)
 	case clouds.GCE:
 		return NewGCEFinder(account, config)

--- a/pkg/kube/handler.go
+++ b/pkg/kube/handler.go
@@ -535,6 +535,8 @@ func (h *Handler) addNode(w http.ResponseWriter, r *http.Request) {
 		DockerVersion:   k.DockerVersion,
 		K8SVersion:      k.K8SVersion,
 		HelmVersion:     k.HelmVersion,
+		User:            k.User,
+		Password:        k.Password,
 
 		NetworkType:           k.Networking.Type,
 		CIDR:                  k.Networking.CIDR,

--- a/pkg/model/kube.go
+++ b/pkg/model/kube.go
@@ -28,6 +28,8 @@ type Kube struct {
 	Auth         Auth      `json:"auth"`
 	SshUser      string    `json:"sshUser"`
 	SshPublicKey []byte    `json:"sshKey"`
+	User                   string                `json:"user" valid:"-"`
+	Password               string                `json:"password" valid:"-"`
 
 	Arch                   string     `json:"arch"`
 	OperatingSystem        string     `json:"operatingSystem"`

--- a/pkg/profile/profile.go
+++ b/pkg/profile/profile.go
@@ -22,6 +22,8 @@ type Profile struct {
 	NetworkType            string                `json:"networkType" valid:"-"`
 	CIDR                   string                `json:"cidr" valid:"-"`
 	HelmVersion            string                `json:"helmVersion" valid:"-"`
+	User                   string                `json:"user" valid:"-"`
+	Password               string                `json:"password" valid:"-"`
 	RBACEnabled            bool                  `json:"rbacEnabled" valid:"-"`
 	CloudSpecificSettings  CloudSpecificSettings `json:"cloudSpecificSettings" valid:"-"`
 	PublicKey              string                `json:"publicKey" valid:"-"`

--- a/pkg/provisioner/handler.go
+++ b/pkg/provisioner/handler.go
@@ -94,6 +94,11 @@ func (h *Handler) Provision(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if req.Profile.User == "" || req.Profile.Password == "" {
+		req.Profile.User = "root"
+		req.Profile.Password = "1234"
+	}
+
 	logrus.Infof("Got discoveryUrl %s", discoveryUrl)
 	config := steps.NewConfig(req.ClusterName, discoveryUrl,
 		req.CloudAccountName, req.Profile)

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -430,6 +430,8 @@ func (tp *TaskProvisioner) buildInitialCluster(ctx context.Context,
 		Zone:         profile.Zone,
 		SshUser:      config.SshConfig.User,
 		SshPublicKey: []byte(config.SshConfig.PublicKey),
+		User: profile.User,
+		Password: profile.Password,
 
 		Auth: model.Auth{
 			Username:  config.CertificatesConfig.Username,

--- a/pkg/workflows/steps/config.go
+++ b/pkg/workflows/steps/config.go
@@ -322,7 +322,7 @@ func NewConfig(clusterName, discoveryUrl, cloudAccountName string, profile profi
 		},
 		SshConfig: SshConfig{
 			Port:      "22",
-			User:      profile.User,
+			User:      "root",
 			Timeout:   10,
 			PublicKey: profile.PublicKey,
 		},

--- a/pkg/workflows/steps/config.go
+++ b/pkg/workflows/steps/config.go
@@ -274,8 +274,8 @@ func NewConfig(clusterName, discoveryUrl, cloudAccountName string, profile profi
 		},
 		CertificatesConfig: CertificatesConfig{
 			KubernetesConfigDir: "/etc/kubernetes",
-			Username:            "root",
-			Password:            "1234",
+			Username:            profile.User,
+			Password:            profile.Password,
 		},
 		NetworkConfig: NetworkConfig{
 			EtcdRepositoryUrl: "https://github.com/coreos/etcd/releases/download",
@@ -291,7 +291,8 @@ func NewConfig(clusterName, discoveryUrl, cloudAccountName string, profile profi
 		FlannelConfig: FlannelConfig{
 			Arch:    profile.Arch,
 			Version: profile.FlannelVersion,
-			// TODO(stgleb): this should be configurable from user side
+			// NOTE(stgleb): this is any host by default works on master nodes
+			// on worker node this host is changed by any master ip address
 			EtcdHost: "0.0.0.0",
 		},
 		KubeletConfig: KubeletConfig{
@@ -309,7 +310,7 @@ func NewConfig(clusterName, discoveryUrl, cloudAccountName string, profile profi
 		PostStartConfig: PostStartConfig{
 			Host:        "localhost",
 			Port:        "8080",
-			Username:    "root",
+			Username:    profile.User,
 			RBACEnabled: profile.RBACEnabled,
 			Timeout:     600,
 		},
@@ -321,7 +322,7 @@ func NewConfig(clusterName, discoveryUrl, cloudAccountName string, profile profi
 		},
 		SshConfig: SshConfig{
 			Port:      "22",
-			User:      "root",
+			User:      profile.User,
 			Timeout:   10,
 			PublicKey: profile.PublicKey,
 		},

--- a/pkg/workflows/workflow.go
+++ b/pkg/workflows/workflow.go
@@ -108,8 +108,8 @@ func Init() {
 	awsMasterWorkflow := []steps.Step{
 		steps.GetStep(amazon.StepNameCreateEC2Instance),
 		steps.GetStep(ssh.StepName),
-		steps.GetStep(downloadk8sbinary.StepName),
 		steps.GetStep(authorizedKeys.StepName),
+		steps.GetStep(downloadk8sbinary.StepName),
 		steps.GetStep(docker.StepName),
 		steps.GetStep(cni.StepName),
 		steps.GetStep(etcd.StepName),


### PR DESCRIPTION
Add user and password to profile and  kube to be able to
customize user name and password.

API changes


```
{
    "clusterName": "gleb",
    "profile": {
        "masterProfiles": [
          {
            "image": "ubuntu-16-04-x64",
            "size": "s-1vcpu-2gb"
        }],
        "nodesProfiles": [
{
            "image": "ubuntu-16-04-x64",
            "size": "s-1vcpu-2gb"
        }
        ],
        "provider": "digitalocean",
        "region": "fra1",
      
         /// New fields
        "user": "root",
        "password": "1234",
        // -----------------------------
        
        "arch": "amd64",
        "operatingSystem": "linux",
        "ubuntuVersion": "xenial",
        "dockerVersion": "17.06.0",
        "K8SVersion": "1.12.2",
        "flannelVersion": "0.10.0",
        "networkType": "vxlan",
        "cidr": "10.2.0.0/16",
        "helmVersion": "2.11.0",
        "rbacEnabled": true
    },
    "cloudAccountName": "do"
}
```